### PR TITLE
feat(tui): sticky Grok-style todo panel at the top of the session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ target/
 # Machine-local notes / ops scrap (self-hosted runner, secrets, host facts)
 local/
 .whycode/todos.json
+.whycode/todos/
 
 # Python bytecode from scripts/ (never commit)
 __pycache__/

--- a/crates/agent/prompts/build.txt
+++ b/crates/agent/prompts/build.txt
@@ -40,6 +40,14 @@ Durable project facts and user preferences survive sessions via the `memory` too
 - Recalled memories may appear under Auto Memory / Recalled Memories in your context; verify against the repo if they look stale.
 - Never store secrets, tokens, or passwords in memory.
 
+## Task list
+Use `todowrite` (alias `todo`) for work with 3+ steps. The user sees this list **live at the top** of the session.
+- Create the list before starting.
+- Keep exactly one item `in_progress`.
+- Mark `completed` as soon as a step is done; do not skip silently.
+- Status updates should send the changed items (merge defaults to true). Use `merge: false` only to replace the whole list.
+- `todoread` shows the current list if you need to check it.
+
 ## Mode switches
 - Pure Q&A sessions: user can use **ask** mode (Ctrl+T) for hard read-only.
 - Design-first work: **plan** mode (Ctrl+T) for a structured plan before build.

--- a/crates/agent/prompts/default.txt
+++ b/crates/agent/prompts/default.txt
@@ -10,3 +10,4 @@ You have access to tools for reading files, writing files, editing files, search
 - Explain your reasoning when making complex changes
 - If you're unsure about something, ask for clarification
 - Follow the user's code style and conventions
+- Use `todowrite` for 3+ step work; the user sees the list live at the top of the session

--- a/crates/agent/prompts/plan.txt
+++ b/crates/agent/prompts/plan.txt
@@ -17,6 +17,9 @@ You are Whycode in **Plan** mode — read-only planning.
    - What you will *not* change
 4. **Stop** — wait for approval or a switch to build; do not start implementation in this mode.
 
+## Task list
+Use `todowrite` when the plan has 3+ concrete steps so the user sees progress at the top of the session. Mark the current step `in_progress`; leave implementation steps `pending` until they switch to build.
+
 ## Intent
 - Design / architecture / "how should we…" → full plan.
 - Small factual questions → short answer; offer a plan only if useful.

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -473,6 +473,16 @@ impl Agent {
         }))
     }
 
+    /// Forward `todowrite` updates onto the turn event channel.
+    fn todo_sink(&self) -> Option<whycode_core::TodoSink> {
+        let tx = self.event_sink.clone()?;
+        Some(std::sync::Arc::new(move |todos| {
+            if let Err(e) = tx.send(TurnEvent::Todos { todos }) {
+                tracing::debug!(error = %e, "todo event dropped (listener closed)");
+            }
+        }))
+    }
+
     /// Attach a long-lived event sink (TUI) for background job notifications
     /// and scheduled prompt enqueue. Safe to call once after channel setup.
     pub fn wire_event_sink(&mut self, sink: EventSink) {
@@ -561,6 +571,7 @@ impl Agent {
             agent_label: self.session_claims.as_ref().map(|_| self.info.name.clone()),
             file_index: self.file_index.clone(),
             panel: self.panel_sink(),
+            todo_sink: self.todo_sink(),
             swarm_hub: self.swarm_hub.clone(),
         }
     }
@@ -3689,6 +3700,14 @@ mod permission_detail_tests {
             assert!(!p.is_empty(), "{name}");
             assert!(!p.contains("Today's date:"), "{name}");
         }
+        assert!(
+            Agent::system_prompt_for("build").contains("todowrite"),
+            "build prompt must instruct todo use"
+        );
+        assert!(
+            Agent::system_prompt_for("plan").contains("todowrite"),
+            "plan prompt must instruct todo use"
+        );
         assert_eq!(
             Agent::system_prompt_for("does-not-exist"),
             DEFAULT_SYSTEM_PROMPT

--- a/crates/agent/src/events.rs
+++ b/crates/agent/src/events.rs
@@ -75,6 +75,8 @@ pub enum TurnEvent {
         to: String,
         text: String,
     },
+    /// Session todo list for the sticky TUI panel (Grok-style).
+    Todos { todos: Vec<whycode_core::TodoItem> },
     /// Subagent lifecycle for the parent TUI (Grok-style strip / tasks pane).
     Subagent {
         id: String,

--- a/crates/agent/src/speculative_read.rs
+++ b/crates/agent/src/speculative_read.rs
@@ -331,6 +331,7 @@ mod tests {
             agent_label: None,
             file_index: None,
             panel: None,
+            todo_sink: None,
             swarm_hub: None,
         };
         maybe_start(&mut jobs, "tc-1", "grep", r#"{"pattern": "x"}"#, &ctx);

--- a/crates/agent/src/subagent.rs
+++ b/crates/agent/src/subagent.rs
@@ -234,6 +234,7 @@ impl SubagentRunner {
             agent_label: self.agent_label.clone(),
             file_index: self.file_index.clone(),
             panel: self.panel.clone(),
+            todo_sink: None,
             swarm_hub: self.swarm_hub.clone(),
         };
 

--- a/crates/agent/src/tests.rs
+++ b/crates/agent/src/tests.rs
@@ -62,6 +62,7 @@ async fn run_bash(agent: &Agent, command: &str) -> whycode_core::types::ToolResu
         agent_label: None,
         file_index: None,
         panel: None,
+        todo_sink: None,
         swarm_hub: None,
     };
     agent
@@ -166,6 +167,7 @@ async fn deny_still_wins_for_non_shell_tools() {
         agent_label: None,
         file_index: None,
         panel: None,
+        todo_sink: None,
         swarm_hub: None,
     };
     let call = whycode_core::types::ToolCall {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2944,6 +2944,12 @@ fn turn_event_to_ci(ev: TurnEvent) -> Option<CiEvent> {
         } => Some(CiEvent::Status {
             message: format!("subagent {id} {status} ({kind}): {description}"),
         }),
+        TurnEvent::Todos { todos } => {
+            let done = whycode_core::todo::terminal_count(&todos);
+            Some(CiEvent::Status {
+                message: format!("todos {done}/{}", todos.len()),
+            })
+        }
     }
 }
 

--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -650,6 +650,17 @@ fn turn_event_to_ci_remaining_variants() {
             message: "panel mermaid".into()
         })
     );
+    assert_eq!(
+        turn_event_to_ci(TE::Todos {
+            todos: vec![
+                whycode_core::TodoItem::new("a", "one", whycode_core::TodoStatus::Completed),
+                whycode_core::TodoItem::new("b", "two", whycode_core::TodoStatus::Pending),
+            ]
+        }),
+        Some(CiEvent::Status {
+            message: "todos 1/2".into()
+        })
+    );
     let intent = turn_event_to_ci(TE::Intent {
         kind: "k".into(),
         confidence: 1.0,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod panel;
 pub mod paths;
 pub mod sandbox;
 pub mod swarm_hub;
+pub mod todo;
 pub mod tool;
 pub mod types;
 
@@ -18,6 +19,10 @@ pub use network::NetworkPolicy;
 pub use panel::{PanelSink, PanelUpdate};
 pub use sandbox::{SandboxFallback, SandboxMode, SandboxSettings};
 pub use swarm_hub::{SwarmHub, SwarmMessage, SwarmMessageListener};
+pub use todo::{
+    TodoItem, TodoList, TodoSink, TodoStatus, all_terminal, apply_todo_update,
+    apply_todowrite_args, load_todos, save_todos, terminal_count, todos_path,
+};
 pub use tool::{Tool, ToolContext};
 
 #[cfg(test)]

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -9,6 +9,7 @@ use crate::panel::*;
 use crate::paths::*;
 use crate::sandbox::*;
 use crate::swarm_hub::*;
+use crate::todo::*;
 use crate::tool::*;
 use crate::types::*;
 use async_trait::async_trait;
@@ -949,6 +950,162 @@ mod panel_tests {
         let _ = format!("{a:?}{b:?}{c:?}{d:?}");
         let sink: PanelSink = Arc::new(|_| {});
         sink(PanelUpdate::Clear);
+    }
+}
+
+// ── todo.rs ───────────────────────────────────────────────
+
+mod todo_tests {
+    use super::*;
+
+    #[test]
+    fn status_parse_mark_and_terminal() {
+        assert_eq!(TodoStatus::parse("pending"), TodoStatus::Pending);
+        assert_eq!(TodoStatus::parse("in_progress"), TodoStatus::InProgress);
+        assert_eq!(TodoStatus::parse("completed"), TodoStatus::Completed);
+        assert_eq!(TodoStatus::parse("cancelled"), TodoStatus::Cancelled);
+        assert_eq!(TodoStatus::parse("nope"), TodoStatus::Pending);
+        assert_eq!(TodoStatus::Pending.as_str(), "pending");
+        assert_eq!(TodoStatus::InProgress.as_str(), "in_progress");
+        assert_eq!(TodoStatus::Completed.as_str(), "completed");
+        assert_eq!(TodoStatus::Cancelled.as_str(), "cancelled");
+        assert_eq!(TodoStatus::Pending.mark(), "☐");
+        assert_eq!(TodoStatus::InProgress.mark(), "▶");
+        assert_eq!(TodoStatus::Completed.mark(), "☑");
+        assert_eq!(TodoStatus::Cancelled.mark(), "✗");
+        assert!(!TodoStatus::Pending.is_terminal());
+        assert!(!TodoStatus::InProgress.is_terminal());
+        assert!(TodoStatus::Completed.is_terminal());
+        assert!(TodoStatus::Cancelled.is_terminal());
+    }
+
+    #[test]
+    fn serde_round_trip_and_unknown_status() {
+        let item = TodoItem::new("a", "do it", TodoStatus::InProgress);
+        let json = serde_json::to_string(&item).unwrap();
+        assert!(json.contains("in_progress"));
+        let back: TodoItem = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, item);
+        let unknown: TodoItem =
+            serde_json::from_str(r#"{"id":"x","content":"y","status":"mystery"}"#).unwrap();
+        assert_eq!(unknown.status, TodoStatus::Pending);
+        let defaults: TodoItem = serde_json::from_str("{}").unwrap();
+        assert!(defaults.id.is_empty());
+        assert!(defaults.content.is_empty());
+        assert_eq!(defaults.status, TodoStatus::Pending);
+        assert_eq!(item.line(), "▶ do it");
+        let list = TodoList {
+            todos: vec![item.clone()],
+        };
+        let _ = format!("{list:?}");
+        assert_eq!(list, list.clone());
+    }
+
+    #[test]
+    fn path_session_scoped_or_fallback() {
+        let root = Path::new("/proj");
+        assert_eq!(
+            todos_path(root, Some("sess-1")),
+            PathBuf::from("/proj/.whycode/todos/sess-1.json")
+        );
+        assert_eq!(
+            todos_path(root, Some("  ")),
+            PathBuf::from("/proj/.whycode/todos.json")
+        );
+        assert_eq!(
+            todos_path(root, None),
+            PathBuf::from("/proj/.whycode/todos.json")
+        );
+    }
+
+    #[test]
+    fn load_missing_invalid_and_save_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(load_todos(dir.path(), None).is_empty());
+        let why = dir.path().join(".whycode");
+        std::fs::create_dir_all(&why).unwrap();
+        std::fs::write(why.join("todos.json"), "not json {{{").unwrap();
+        assert!(load_todos(dir.path(), None).is_empty());
+        std::fs::write(why.join("todos.json"), r#"{"other":1}"#).unwrap();
+        assert!(load_todos(dir.path(), None).is_empty());
+
+        let items = vec![
+            TodoItem::new("1", "a", TodoStatus::Pending),
+            TodoItem::new("2", "b", TodoStatus::Completed),
+        ];
+        save_todos(dir.path(), Some("abc"), &items).unwrap();
+        let loaded = load_todos(dir.path(), Some("abc"));
+        assert_eq!(loaded, items);
+        assert!(load_todos(dir.path(), Some("other")).is_empty());
+    }
+
+    #[test]
+    fn save_fails_when_parent_is_a_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("file");
+        std::fs::write(&blocker, "x").unwrap();
+        let err = save_todos(&blocker, None, &[]).unwrap_err();
+        assert!(err.contains("creating todo dir"), "{err}");
+    }
+
+    #[test]
+    fn save_fails_when_target_is_a_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let why = dir.path().join(".whycode");
+        std::fs::create_dir_all(why.join("todos.json")).unwrap();
+        let err = save_todos(dir.path(), None, &[]).unwrap_err();
+        assert!(err.contains("writing todos"), "{err}");
+    }
+
+    #[test]
+    fn merge_by_id_and_replace() {
+        let existing = vec![
+            TodoItem::new("a", "old", TodoStatus::Pending),
+            TodoItem::new("b", "keep", TodoStatus::Pending),
+        ];
+        let incoming = vec![
+            TodoItem::new("a", "new", TodoStatus::Completed),
+            TodoItem::new("c", "add", TodoStatus::InProgress),
+            TodoItem::new("", "no-id", TodoStatus::Pending),
+        ];
+        let merged = apply_todo_update(existing.clone(), incoming.clone(), true);
+        assert_eq!(merged.len(), 4);
+        assert_eq!(merged[0].content, "new");
+        assert_eq!(merged[0].status, TodoStatus::Completed);
+        assert_eq!(merged[1].content, "keep");
+        assert_eq!(merged[2].id, "c");
+        assert_eq!(merged[3].content, "no-id");
+        let replaced = apply_todo_update(existing, incoming, false);
+        assert_eq!(replaced.len(), 3);
+    }
+
+    #[test]
+    fn apply_todowrite_args_default_merge() {
+        let existing = vec![TodoItem::new("a", "old", TodoStatus::Pending)];
+        let next = apply_todowrite_args(
+            &existing,
+            &json!({"todos":[{"id":"a","content":"upd","status":"completed"}]}),
+        )
+        .unwrap();
+        assert_eq!(next[0].content, "upd");
+        let replaced = apply_todowrite_args(
+            &existing,
+            &json!({
+                "merge": false,
+                "todos":[{"id":"z","content":"only","status":"pending"}]
+            }),
+        )
+        .unwrap();
+        assert_eq!(replaced.len(), 1);
+        assert_eq!(replaced[0].id, "z");
+        assert!(apply_todowrite_args(&existing, &json!({})).is_none());
+        assert!(apply_todowrite_args(&existing, &json!({"todos":"nope"})).is_none());
+        assert_eq!(terminal_count(&next), 1);
+        assert!(all_terminal(&next));
+        assert!(!all_terminal(&[]));
+        assert!(!all_terminal(&existing));
+        let sink: TodoSink = Arc::new(|_| {});
+        sink(next);
     }
 }
 

--- a/crates/core/src/todo.rs
+++ b/crates/core/src/todo.rs
@@ -1,0 +1,181 @@
+//! Session todo list (Grok-style sticky TUI panel).
+//!
+//! Tools write through [`TodoSink`]; the host maps that onto [`crate::todo`]
+//! events. Storage is session-scoped under `.whycode/todos/<session_id>.json`.
+
+use serde::{Deserialize, Deserializer, Serialize};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+/// Status of one todo item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TodoStatus {
+    #[default]
+    Pending,
+    InProgress,
+    Completed,
+    Cancelled,
+}
+
+impl TodoStatus {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "pending",
+            Self::InProgress => "in_progress",
+            Self::Completed => "completed",
+            Self::Cancelled => "cancelled",
+        }
+    }
+
+    /// ASCII mark used in the TUI panel and sidebar.
+    pub fn mark(self) -> &'static str {
+        match self {
+            Self::Pending => "☐",
+            Self::InProgress => "▶",
+            Self::Completed => "☑",
+            Self::Cancelled => "✗",
+        }
+    }
+
+    /// True when the item is finished (done or skipped).
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Cancelled)
+    }
+
+    pub fn parse(s: &str) -> Self {
+        match s {
+            "in_progress" => Self::InProgress,
+            "completed" => Self::Completed,
+            "cancelled" => Self::Cancelled,
+            _ => Self::Pending,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TodoStatus {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(Self::parse(&s))
+    }
+}
+
+/// One row in the session todo list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoItem {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub content: String,
+    #[serde(default)]
+    pub status: TodoStatus,
+}
+
+impl TodoItem {
+    pub fn new(id: impl Into<String>, content: impl Into<String>, status: TodoStatus) -> Self {
+        Self {
+            id: id.into(),
+            content: content.into(),
+            status,
+        }
+    }
+
+    pub fn line(&self) -> String {
+        format!("{} {}", self.status.mark(), self.content)
+    }
+}
+
+/// On-disk envelope.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TodoList {
+    #[serde(default)]
+    pub todos: Vec<TodoItem>,
+}
+
+/// Callback the host (agent loop) installs so `todowrite` can reach the TUI.
+pub type TodoSink = Arc<dyn Fn(Vec<TodoItem>) + Send + Sync>;
+
+/// Path of the session todo file.
+///
+/// With a non-empty `session_id`: `.whycode/todos/<id>.json`.
+/// Otherwise (tests, missing id): `.whycode/todos.json`.
+pub fn todos_path(working_dir: &Path, session_id: Option<&str>) -> PathBuf {
+    let dir = working_dir.join(".whycode");
+    match session_id.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(id) => dir.join("todos").join(format!("{id}.json")),
+        None => dir.join("todos.json"),
+    }
+}
+
+/// Load todos. Missing or invalid files yield an empty list.
+pub fn load_todos(working_dir: &Path, session_id: Option<&str>) -> Vec<TodoItem> {
+    let path = todos_path(working_dir, session_id);
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return Vec::new();
+    };
+    serde_json::from_str::<TodoList>(&raw)
+        .map(|list| list.todos)
+        .unwrap_or_default()
+}
+
+/// Persist the full list. Creates `.whycode` / `.whycode/todos` as needed.
+pub fn save_todos(
+    working_dir: &Path,
+    session_id: Option<&str>,
+    todos: &[TodoItem],
+) -> Result<(), String> {
+    let path = todos_path(working_dir, session_id);
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("creating todo dir: {e}"))?;
+    }
+    // TodoList is always serializable (plain strings + a closed status enum).
+    let json = serde_json::to_string_pretty(&TodoList {
+        todos: todos.to_vec(),
+    })
+    .unwrap_or_else(|_| String::from("{\"todos\":[]}"));
+    std::fs::write(&path, json).map_err(|e| format!("writing todos: {e}"))
+}
+
+/// Merge incoming items into `existing` by `id`. Empty ids always append.
+pub fn apply_todo_update(
+    mut existing: Vec<TodoItem>,
+    incoming: Vec<TodoItem>,
+    merge: bool,
+) -> Vec<TodoItem> {
+    if !merge {
+        return incoming;
+    }
+    for new in incoming {
+        if !new.id.is_empty()
+            && let Some(old) = existing.iter_mut().find(|t| t.id == new.id)
+        {
+            *old = new;
+        } else {
+            existing.push(new);
+        }
+    }
+    existing
+}
+
+/// Apply a `todowrite` / `todo` tool argument object.
+///
+/// `merge` defaults to **true** (Grok Build). Returns `None` when `todos` is
+/// missing or not an array of items.
+pub fn apply_todowrite_args(
+    existing: &[TodoItem],
+    input: &serde_json::Value,
+) -> Option<Vec<TodoItem>> {
+    let incoming: Vec<TodoItem> = serde_json::from_value(input.get("todos")?.clone()).ok()?;
+    let merge = input.get("merge").and_then(|v| v.as_bool()).unwrap_or(true);
+    Some(apply_todo_update(existing.to_vec(), incoming, merge))
+}
+
+/// Completed + cancelled count.
+pub fn terminal_count(todos: &[TodoItem]) -> usize {
+    todos.iter().filter(|t| t.status.is_terminal()).count()
+}
+
+/// True when every item is completed or cancelled (and the list is non-empty).
+pub fn all_terminal(todos: &[TodoItem]) -> bool {
+    !todos.is_empty() && todos.iter().all(|t| t.status.is_terminal())
+}

--- a/crates/core/src/tool.rs
+++ b/crates/core/src/tool.rs
@@ -28,6 +28,8 @@ pub struct ToolContext {
     pub file_index: Option<std::sync::Arc<whycode_index::WorkspaceIndex>>,
     /// Optional sink so the `panel` tool can pin a file / diff / mermaid.
     pub panel: Option<PanelSink>,
+    /// Optional sink so `todowrite` can update the host todo panel live.
+    pub todo_sink: Option<crate::todo::TodoSink>,
     /// Swarm mailbox (DM / broadcast).
     pub swarm_hub: Option<SwarmHub>,
 }
@@ -44,6 +46,7 @@ impl std::fmt::Debug for ToolContext {
             .field("agent_label", &self.agent_label)
             .field("file_index", &self.file_index.as_ref().map(|_| "Some"))
             .field("panel", &self.panel.as_ref().map(|_| "Some"))
+            .field("todo_sink", &self.todo_sink.as_ref().map(|_| "Some"))
             .field("swarm_hub", &self.swarm_hub)
             .finish()
     }
@@ -61,6 +64,7 @@ impl ToolContext {
             agent_label: None,
             file_index: None,
             panel: None,
+            todo_sink: None,
             swarm_hub: None,
         }
     }
@@ -76,6 +80,7 @@ impl ToolContext {
             agent_label: None,
             file_index: None,
             panel: None,
+            todo_sink: None,
             swarm_hub: None,
         }
     }

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -141,6 +141,7 @@ pub(crate) async fn handle_rpc(
                     agent_label: None,
                     file_index: None,
                     panel: None,
+                    todo_sink: None,
                     swarm_hub: None,
                 };
                 let result = executor.execute(&call, &ctx, permissions).await;

--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -584,6 +584,13 @@ fn turn_event_json(ev: &TurnEvent) -> Option<serde_json::Value> {
                 "elapsed_ms": elapsed_ms,
             })
         }
+        TurnEvent::Todos { todos } => {
+            serde_json::json!({
+                "type": "todos",
+                "count": todos.len(),
+                "done": whycode_core::todo::terminal_count(todos),
+            })
+        }
         TurnEvent::Panel(update) => match update {
             whycode_core::PanelUpdate::Clear => {
                 serde_json::json!({"type": "panel", "action": "clear"})

--- a/crates/server/src/v1.rs
+++ b/crates/server/src/v1.rs
@@ -532,6 +532,7 @@ pub(crate) fn from_turn_event(ev: &TurnEvent) -> Option<SdkEvent> {
         // TUI-only chrome — not part of the public v1 contract.
         TurnEvent::EnqueuePrompt { .. }
         | TurnEvent::Panel(_)
+        | TurnEvent::Todos { .. }
         | TurnEvent::SwarmMessage { .. }
         | TurnEvent::FileStale { .. }
         | TurnEvent::Subagent { .. } => return None,
@@ -600,6 +601,16 @@ mod tests {
 
         // TUI-only chrome is not part of the v1 contract.
         assert!(from_turn_event(&TurnEvent::Panel(PanelUpdate::Clear)).is_none());
+        assert!(
+            from_turn_event(&TurnEvent::Todos {
+                todos: vec![whycode_core::TodoItem::new(
+                    "a",
+                    "x",
+                    whycode_core::TodoStatus::Pending
+                )]
+            })
+            .is_none()
+        );
         assert!(
             from_turn_event(&TurnEvent::SwarmMessage {
                 from: "a".into(),

--- a/crates/tools/src/agent_tools/todo_read.rs
+++ b/crates/tools/src/agent_tools/todo_read.rs
@@ -1,21 +1,10 @@
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::path::Path;
 
 use crate::tool::{Tool, ToolContext};
+use whycode_core::todo::load_todos;
 use whycode_core::types::ToolResult;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct TodoItem {
-    id: String,
-    content: String,
-    status: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct TodoList {
-    todos: Vec<TodoItem>,
-}
 
 /// Read the current session todo list — OpenCode `todoread` tool.
 pub struct TodoReadTool;
@@ -51,59 +40,71 @@ impl Tool for TodoReadTool {
     }
 
     async fn execute(&self, _args: serde_json::Value, ctx: &ToolContext) -> ToolResult {
-        let todos_path = std::path::Path::new(&ctx.working_dir)
-            .join(".whycode")
-            .join("todos.json");
-
-        if !todos_path.exists() {
+        let todos = load_todos(Path::new(&ctx.working_dir), ctx.session_id.as_deref());
+        if todos.is_empty() {
             return ToolResult {
                 tool_call_id: String::new(),
                 content: "No todos yet. Use todowrite to create a task list.".to_string(),
                 is_error: false,
             };
         }
-
-        match std::fs::read_to_string(&todos_path) {
-            Ok(content) => match serde_json::from_str::<TodoList>(&content) {
-                Ok(list) => {
-                    if list.todos.is_empty() {
-                        return ToolResult {
-                            tool_call_id: String::new(),
-                            content: "Todo list is empty.".to_string(),
-                            is_error: false,
-                        };
-                    }
-                    let mut result = String::from("Todos:\n");
-                    for item in &list.todos {
-                        let icon = match item.status.as_str() {
-                            "pending" => "⏳",
-                            "in_progress" => "🔄",
-                            "completed" => "✅",
-                            "cancelled" => "❌",
-                            _ => "❓",
-                        };
-                        result.push_str(&format!(
-                            "  {} [{}] {} ({})\n",
-                            icon, item.id, item.content, item.status
-                        ));
-                    }
-                    ToolResult {
-                        tool_call_id: String::new(),
-                        content: result,
-                        is_error: false,
-                    }
-                }
-                Err(e) => ToolResult {
-                    tool_call_id: String::new(),
-                    content: format!("Failed to parse todos: {}", e),
-                    is_error: true,
-                },
-            },
-            Err(e) => ToolResult {
-                tool_call_id: String::new(),
-                content: format!("Failed to read todos: {}", e),
-                is_error: true,
-            },
+        let mut result = String::from("Todos:\n");
+        for item in &todos {
+            result.push_str(&format!(
+                "  {} [{}] {} ({})\n",
+                item.status.mark(),
+                item.id,
+                item.content,
+                item.status.as_str()
+            ));
         }
+        ToolResult {
+            tool_call_id: String::new(),
+            content: result,
+            is_error: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use whycode_core::todo::{TodoItem, TodoStatus, save_todos};
+
+    fn ctx(dir: &std::path::Path, session: Option<&str>) -> ToolContext {
+        let mut c = ToolContext::unsandboxed(dir.to_string_lossy().into_owned());
+        c.session_id = session.map(str::to_string);
+        c
+    }
+
+    #[tokio::test]
+    async fn empty_and_populated() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = TodoReadTool::new();
+        assert_eq!(tool.name(), "todoread");
+        let empty = tool.execute(json!({}), &ctx(dir.path(), None)).await;
+        assert!(!empty.is_error);
+        assert!(empty.content.contains("No todos yet"));
+
+        save_todos(
+            dir.path(),
+            Some("s1"),
+            &[
+                TodoItem::new("a", "one", TodoStatus::Pending),
+                TodoItem::new("b", "two", TodoStatus::InProgress),
+                TodoItem::new("c", "done", TodoStatus::Completed),
+                TodoItem::new("d", "skip", TodoStatus::Cancelled),
+            ],
+        )
+        .unwrap();
+        let list = tool.execute(json!({}), &ctx(dir.path(), Some("s1"))).await;
+        assert!(list.content.contains("☐ [a] one (pending)"));
+        assert!(list.content.contains("▶ [b] two (in_progress)"));
+        assert!(list.content.contains("☑ [c] done (completed)"));
+        assert!(list.content.contains("✗ [d] skip (cancelled)"));
+        let other = tool
+            .execute(json!({}), &ctx(dir.path(), Some("other")))
+            .await;
+        assert!(other.content.contains("No todos yet"));
     }
 }

--- a/crates/tools/src/agent_tools/todo_write.rs
+++ b/crates/tools/src/agent_tools/todo_write.rs
@@ -1,21 +1,10 @@
 use async_trait::async_trait;
-use serde::{Deserialize, Serialize};
 use serde_json::json;
+use std::path::Path;
 
 use crate::tool::{Tool, ToolContext};
+use whycode_core::todo::{TodoItem, apply_todo_update, load_todos, save_todos};
 use whycode_core::types::ToolResult;
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct TodoItem {
-    id: String,
-    content: String,
-    status: String,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-struct TodoList {
-    todos: Vec<TodoItem>,
-}
 
 pub struct TodoWriteTool {
     name: &'static str,
@@ -45,7 +34,9 @@ impl Tool for TodoWriteTool {
     }
 
     fn description(&self) -> &str {
-        "Create and manage a structured task list"
+        "Create and manage a structured task list. The user sees this list live at the top of the \
+         session. Use for any task with 3+ steps. Mark the current item in_progress (only one) \
+         and completed as soon as the step is done. Default merge=true updates items by id."
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -77,7 +68,7 @@ impl Tool for TodoWriteTool {
                 },
                 "merge": {
                     "type": "boolean",
-                    "description": "If true, merge with existing todos; if false, replace entirely"
+                    "description": "If true (default), merge with existing todos by id; if false, replace entirely"
                 }
             },
             "required": ["todos"]
@@ -85,114 +76,178 @@ impl Tool for TodoWriteTool {
     }
 
     async fn execute(&self, args: serde_json::Value, ctx: &ToolContext) -> ToolResult {
-        let merge = args.get("merge").and_then(|v| v.as_bool()).unwrap_or(false);
+        let merge = args.get("merge").and_then(|v| v.as_bool()).unwrap_or(true);
 
-        // Parse new todos from args
         let new_todos: Vec<TodoItem> = match serde_json::from_value(args["todos"].clone()) {
             Ok(t) => t,
             Err(e) => {
                 return ToolResult {
                     tool_call_id: String::new(),
-                    content: format!("Error parsing todos: {}", e),
+                    content: format!("Error parsing todos: {e}"),
                     is_error: true,
                 };
             }
         };
 
-        // Determine the storage directory
-        let whycode_dir = std::path::Path::new(&ctx.working_dir).join(".whycode");
-        let todos_path = whycode_dir.join("todos.json");
-
-        // Create .whycode directory if it doesn't exist
-        if let Err(e) = std::fs::create_dir_all(&whycode_dir) {
-            return ToolResult {
-                tool_call_id: String::new(),
-                content: format!("Error creating .whycode directory: {}", e),
-                is_error: true,
-            };
-        }
-
-        // Load existing todos if merging
-        let final_todos: Vec<TodoItem> = if merge {
-            match std::fs::read_to_string(&todos_path) {
-                Ok(content) => {
-                    match serde_json::from_str::<TodoList>(&content) {
-                        Ok(list) => {
-                            let mut existing = list.todos;
-                            // Merge: update existing items by id, add new ones
-                            for new_item in new_todos {
-                                if let Some(existing_item) =
-                                    existing.iter_mut().find(|t| t.id == new_item.id)
-                                {
-                                    existing_item.content = new_item.content;
-                                    existing_item.status = new_item.status;
-                                } else {
-                                    existing.push(new_item);
-                                }
-                            }
-                            existing
-                        }
-                        Err(_) => new_todos,
-                    }
-                }
-                Err(_) => new_todos,
-            }
+        let working = Path::new(&ctx.working_dir);
+        let session_id = ctx.session_id.as_deref();
+        let existing = if merge {
+            load_todos(working, session_id)
         } else {
-            new_todos
+            Vec::new()
         };
+        let final_todos = apply_todo_update(existing, new_todos, merge);
 
-        // Save todos
-        let todo_list = TodoList {
-            todos: final_todos.clone(),
-        };
-
-        let json_str = match serde_json::to_string_pretty(&todo_list) {
-            Ok(s) => s,
-            Err(e) => {
-                return ToolResult {
-                    tool_call_id: String::new(),
-                    content: format!("Error serializing todos: {}", e),
-                    is_error: true,
-                };
-            }
-        };
-
-        if let Err(e) = std::fs::write(&todos_path, &json_str) {
+        if let Err(e) = save_todos(working, session_id, &final_todos) {
             return ToolResult {
                 tool_call_id: String::new(),
-                content: format!("Error writing todos file: {}", e),
+                content: format!("Error writing todos: {e}"),
                 is_error: true,
             };
         }
 
-        // Format the result
-        let mut result = String::from("Todos:\n");
-        let status_icons = [
-            ("pending", "⏳"),
-            ("in_progress", "🔄"),
-            ("completed", "✅"),
-            ("cancelled", "❌"),
-        ];
-
-        for item in &final_todos {
-            let icon = status_icons
-                .iter()
-                .find(|(s, _)| s == &item.status.as_str())
-                .map(|(_, i)| *i)
-                .unwrap_or("❓");
-            result.push_str(&format!("  {} [{}] {}\n", icon, item.id, item.content));
+        if let Some(sink) = &ctx.todo_sink {
+            sink(final_todos.clone());
         }
-
-        result.push_str(&format!(
-            "\nStored {} todos in {}",
-            final_todos.len(),
-            todos_path.display()
-        ));
 
         ToolResult {
             tool_call_id: String::new(),
-            content: result,
+            content: format_todo_result(&final_todos, working, session_id),
             is_error: false,
         }
+    }
+}
+
+fn format_todo_result(todos: &[TodoItem], working: &Path, session_id: Option<&str>) -> String {
+    let mut result = String::from("Todos:\n");
+    for item in todos {
+        result.push_str(&format!(
+            "  {} [{}] {}\n",
+            item.status.mark(),
+            item.id,
+            item.content
+        ));
+    }
+    result.push_str(&format!(
+        "\nStored {} todos in {}",
+        todos.len(),
+        whycode_core::todo::todos_path(working, session_id).display()
+    ));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+    use whycode_core::todo::TodoStatus;
+
+    fn ctx(dir: &std::path::Path, session: Option<&str>) -> ToolContext {
+        let mut c = ToolContext::unsandboxed(dir.to_string_lossy().into_owned());
+        c.session_id = session.map(str::to_string);
+        c
+    }
+
+    #[tokio::test]
+    async fn writes_merges_and_notifies_sink() {
+        let dir = tempfile::tempdir().unwrap();
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let cap = captured.clone();
+        let mut c = ctx(dir.path(), Some("sess-a"));
+        c.todo_sink = Some(Arc::new(move |todos| {
+            *cap.lock().unwrap() = todos;
+        }));
+
+        let tool = TodoWriteTool::new();
+        assert_eq!(tool.name(), "todowrite");
+        assert!(tool.description().contains("live"));
+        assert_eq!(TodoWriteTool::as_todo().name(), "todo");
+        let _ = TodoWriteTool::default();
+
+        let first = tool
+            .execute(
+                json!({"todos":[
+                    {"id":"a","content":"one","status":"pending"},
+                    {"id":"b","content":"two","status":"in_progress"}
+                ]}),
+                &c,
+            )
+            .await;
+        assert!(!first.is_error, "{}", first.content);
+        assert!(first.content.contains("☐ [a] one"));
+        assert!(first.content.contains("▶ [b] two"));
+        assert_eq!(captured.lock().unwrap().len(), 2);
+
+        let merged = tool
+            .execute(
+                json!({"todos":[{"id":"a","content":"one","status":"completed"}]}),
+                &c,
+            )
+            .await;
+        assert!(!merged.is_error, "{}", merged.content);
+        let list = captured.lock().unwrap().clone();
+        assert_eq!(list.len(), 2);
+        assert_eq!(list[0].status, TodoStatus::Completed);
+        assert_eq!(list[1].status, TodoStatus::InProgress);
+
+        let replaced = tool
+            .execute(
+                json!({
+                    "merge": false,
+                    "todos":[{"id":"z","content":"only","status":"pending"}]
+                }),
+                &c,
+            )
+            .await;
+        assert!(!replaced.is_error, "{}", replaced.content);
+        assert_eq!(captured.lock().unwrap().len(), 1);
+
+        let bad = tool.execute(json!({"todos": "nope"}), &c).await;
+        assert!(bad.is_error);
+        assert!(bad.content.contains("Error parsing todos"));
+    }
+
+    #[tokio::test]
+    async fn session_path_differs_from_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool = TodoWriteTool::new();
+        let with_id = ctx(dir.path(), Some("s1"));
+        let without = ctx(dir.path(), None);
+        let _ = tool
+            .execute(
+                json!({"todos":[{"id":"a","content":"sess","status":"pending"}]}),
+                &with_id,
+            )
+            .await;
+        let _ = tool
+            .execute(
+                json!({"todos":[{"id":"b","content":"fb","status":"pending"}]}),
+                &without,
+            )
+            .await;
+        let sess = whycode_core::todo::load_todos(dir.path(), Some("s1"));
+        let fb = whycode_core::todo::load_todos(dir.path(), None);
+        assert_eq!(sess[0].content, "sess");
+        assert_eq!(fb[0].content, "fb");
+    }
+
+    #[tokio::test]
+    async fn save_error_is_tool_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("not-a-dir");
+        std::fs::write(&blocker, "x").unwrap();
+        let c = ctx(&blocker, None);
+        let out = TodoWriteTool::new()
+            .execute(
+                json!({"todos":[{"id":"a","content":"x","status":"pending"}]}),
+                &c,
+            )
+            .await;
+        assert!(out.is_error);
+        assert!(
+            out.content.contains("Error writing todos"),
+            "{}",
+            out.content
+        );
     }
 }

--- a/crates/tools/tests/git_tools.rs
+++ b/crates/tools/tests/git_tools.rs
@@ -27,6 +27,7 @@ fn repo_ctx() -> ToolContext {
         agent_label: None,
         file_index: None,
         panel: None,
+        todo_sink: None,
         swarm_hub: None,
     }
 }

--- a/crates/tools/tests/github_existing.rs
+++ b/crates/tools/tests/github_existing.rs
@@ -22,6 +22,7 @@ fn neutral_ctx() -> ToolContext {
         agent_label: None,
         file_index: None,
         panel: None,
+        todo_sink: None,
         swarm_hub: None,
     }
 }

--- a/crates/tools/tests/tools.rs
+++ b/crates/tools/tests/tools.rs
@@ -23,6 +23,7 @@ fn temp_ctx(dir: &TempDir) -> ToolContext {
         agent_label: None,
         file_index: None,
         panel: None,
+        todo_sink: None,
         swarm_hub: None,
     }
 }

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -430,8 +430,6 @@ pub struct SidebarState {
     pub diagnostics: usize,
     /// MCP server status messages.
     pub mcp_status: Vec<String>,
-    /// TODO items.
-    pub todos: Vec<String>,
     /// Agent-pinned preview (file / diff / mermaid).
     pub preview: SidebarPreview,
 }
@@ -504,7 +502,6 @@ impl Default for SidebarState {
             file_tree: vec![],
             diagnostics: 0,
             mcp_status: vec![],
-            todos: vec![],
             preview: SidebarPreview::None,
         }
     }
@@ -1319,6 +1316,10 @@ pub struct TuiApp {
     pub turn_usage: Option<whycode_core::types::Usage>,
     /// Mouse `[stop]` (or future UI) requested cancel — run loop consumes this.
     pub pending_cancel: bool,
+    /// Active session id (todo file key; empty before the first session).
+    pub session_id: String,
+    /// Session todo list (sticky panel under the header).
+    pub todos: Vec<whycode_core::TodoItem>,
     /// Live + finished child sessions (Grok tasks pane / top strip).
     pub subagents: Vec<SubagentUi>,
     /// When set, the framed child transcript overlays the parent session.
@@ -1755,6 +1756,8 @@ impl TuiApp {
             turn_started_at: None,
             turn_usage: None,
             pending_cancel: false,
+            session_id: String::new(),
+            todos: Vec::new(),
             subagents: Vec::new(),
             open_subagent: None,
             subagent_strip_hit: Vec::new(),
@@ -2661,6 +2664,15 @@ impl TuiApp {
     pub fn load_messages_from_session(&mut self, session: &whycode_session::session::Session) {
         self.messages = chat_messages_from_session(session);
         self.session_title = session.title.clone();
+        self.session_id = session.id.clone();
+        self.todos = whycode_core::todo::load_todos(
+            &self.project_dir,
+            if session.id.is_empty() {
+                None
+            } else {
+                Some(session.id.as_str())
+            },
+        );
         self.scroll_offset = 0;
         self.auto_scroll = true;
         self.selected_msg = None;
@@ -2688,6 +2700,8 @@ impl TuiApp {
         view.turn_usage = self.turn_usage.clone();
         view.context_used = self.context_used;
         view.pending_suggestion = self.pending_suggestion.clone();
+        view.session_id = self.session_id.clone();
+        view.todos = self.todos.clone();
     }
 
     /// Restore a previously saved per-session view state (switching back).
@@ -2707,6 +2721,8 @@ impl TuiApp {
         self.turn_usage = view.turn_usage.clone();
         self.context_used = view.context_used;
         self.pending_suggestion = view.pending_suggestion.clone();
+        self.session_id = view.session_id.clone();
+        self.todos = view.todos.clone();
         self.dialogs.clear();
         self.mark_dirty();
     }
@@ -2730,6 +2746,8 @@ impl TuiApp {
         self.turn_usage = view.turn_usage.take();
         self.context_used = view.context_used;
         self.pending_suggestion = view.pending_suggestion.take();
+        self.session_id = std::mem::take(&mut view.session_id);
+        self.todos = std::mem::take(&mut view.todos);
     }
 
     /// Move this app's view fields back into `view` (no transcript clone).
@@ -2750,6 +2768,8 @@ impl TuiApp {
         view.turn_usage = self.turn_usage.take();
         view.context_used = self.context_used;
         view.pending_suggestion = self.pending_suggestion.take();
+        view.session_id = std::mem::take(&mut self.session_id);
+        view.todos = std::mem::take(&mut self.todos);
     }
 
     /// Add a message to the chat view.

--- a/crates/tui/src/run.rs
+++ b/crates/tui/src/run.rs
@@ -411,6 +411,7 @@ async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
 
     let mut session = Session::new(opts.project_dir.clone(), system_prompt.clone());
     app.session_title = session.title.clone();
+    app.session_id = session.id.clone();
     if app.session_list.sessions.is_empty() {
         app.session_list.sessions = load_session_entries();
     }
@@ -818,6 +819,7 @@ pub async fn run(opts: TuiRunOptions) -> anyhow::Result<()> {
                     rt.agent.load_mcp(&config).await;
                     maybe_session_auto_index(&project_dir, &config, &mut app);
                     refresh_sidebar(&mut app, &config, &file_index);
+                    load_app_todos(&mut app);
                     if !app.toasts.is_empty() {
                         app.mark_dirty();
                     }
@@ -3510,6 +3512,11 @@ fn apply_turn_event(app: &mut TuiApp, ev: TurnEvent) {
                 other => other,
             };
             app.status_message = format!("tool: {shown}");
+            if matches!(name.as_str(), "todowrite" | "todo")
+                && let Some(next) = whycode_core::todo::apply_todowrite_args(&app.todos, &input)
+            {
+                app.todos = next;
+            }
             app.add_tool_call(id, name, input);
         }
         TurnEvent::ToolEnd {
@@ -3658,6 +3665,10 @@ fn apply_turn_event(app: &mut TuiApp, ev: TurnEvent) {
         TurnEvent::Panel(update) => {
             apply_panel_update(app, update);
         }
+        TurnEvent::Todos { todos } => {
+            app.todos = todos;
+            app.mark_dirty();
+        }
         TurnEvent::Subagent {
             id,
             kind,
@@ -3724,7 +3735,7 @@ pub(crate) fn apply_panel_update(app: &mut TuiApp, update: whycode_core::PanelUp
     app.mark_dirty();
 }
 
-/// Refresh sidebar lists from the workspace index, config, and todos.json.
+/// Refresh sidebar lists from the workspace index, config, and session todos.
 fn refresh_sidebar(
     app: &mut TuiApp,
     config: &whycode_config::Config,
@@ -3753,37 +3764,17 @@ fn refresh_sidebar(
         .collect();
     mcp.sort();
     app.sidebar.mcp_status = mcp;
-
-    app.sidebar.todos = load_sidebar_todos(&app.project_dir);
 }
 
-fn load_sidebar_todos(project_dir: &std::path::Path) -> Vec<String> {
-    let path = project_dir.join(".whycode").join("todos.json");
-    let Ok(raw) = std::fs::read_to_string(path) else {
-        return Vec::new();
-    };
-    let parsed: serde_json::Value = serde_json::from_str(&raw).unwrap_or(serde_json::Value::Null);
-    let Some(items) = parsed.get("todos").and_then(|v| v.as_array()) else {
-        return Vec::new();
-    };
-    items
-        .iter()
-        .filter_map(|item| {
-            let content = item.get("content")?.as_str()?;
-            let status = item
-                .get("status")
-                .and_then(|s| s.as_str())
-                .unwrap_or("pending");
-            let mark = match status {
-                "completed" => "☑",
-                "cancelled" => "✗",
-                "in_progress" => "…",
-                _ => "☐",
-            };
-            Some(format!("{mark} {content}"))
-        })
-        .take(40)
-        .collect()
+fn load_app_todos(app: &mut TuiApp) {
+    app.todos = whycode_core::todo::load_todos(
+        &app.project_dir,
+        if app.session_id.is_empty() {
+            None
+        } else {
+            Some(app.session_id.as_str())
+        },
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -4152,6 +4143,8 @@ async fn handle_slash(text: &str, ctx: &mut SlashContext<'_>) {
                 ),
             );
             ctx.app.session_title = ctx.session.title.clone();
+            ctx.app.session_id = ctx.session.id.clone();
+            ctx.app.todos.clear();
             ctx.app.messages.clear();
             ctx.app.sync_context_estimate(ctx.session);
             ctx.app.turn_usage = None;
@@ -5784,10 +5777,9 @@ mod tests {
     }
 
     #[test]
-    fn load_sidebar_todos_missing_and_valid() {
+    fn load_session_todos_missing_and_valid() {
         let dir = tempfile::tempdir().unwrap();
-        // No todos.json → empty.
-        assert!(load_sidebar_todos(dir.path()).is_empty());
+        assert!(whycode_core::todo::load_todos(dir.path(), None).is_empty());
 
         let whycode = dir.path().join(".whycode");
         std::fs::create_dir_all(&whycode).unwrap();
@@ -5802,24 +5794,24 @@ mod tests {
             ]}"#,
         )
         .unwrap();
-        let todos = load_sidebar_todos(dir.path());
+        let todos = whycode_core::todo::load_todos(dir.path(), None);
         assert_eq!(todos.len(), 5);
-        assert_eq!(todos[0], "☐ finish task");
-        assert_eq!(todos[1], "☑ done item");
-        assert_eq!(todos[2], "… working now");
-        assert_eq!(todos[3], "✗ skipped");
-        assert_eq!(todos[4], "☐ no status");
+        assert_eq!(todos[0].line(), "☐ finish task");
+        assert_eq!(todos[1].line(), "☑ done item");
+        assert_eq!(todos[2].line(), "▶ working now");
+        assert_eq!(todos[3].line(), "✗ skipped");
+        assert_eq!(todos[4].line(), "☐ no status");
     }
 
     #[test]
-    fn load_sidebar_todos_invalid_json_and_wrong_shape() {
+    fn load_session_todos_invalid_json_and_wrong_shape() {
         let dir = tempfile::tempdir().unwrap();
         let whycode = dir.path().join(".whycode");
         std::fs::create_dir_all(&whycode).unwrap();
         std::fs::write(whycode.join("todos.json"), "not json {{{").unwrap();
-        assert!(load_sidebar_todos(dir.path()).is_empty());
+        assert!(whycode_core::todo::load_todos(dir.path(), None).is_empty());
         std::fs::write(whycode.join("todos.json"), r#"{"other": 1}"#).unwrap();
-        assert!(load_sidebar_todos(dir.path()).is_empty());
+        assert!(whycode_core::todo::load_todos(dir.path(), None).is_empty());
     }
 
     #[test]
@@ -6342,6 +6334,44 @@ mod tests {
                 .iter()
                 .any(|t| t.message.contains("stale"))
         );
+
+        apply_turn_event(
+            &mut app,
+            TurnEvent::Todos {
+                todos: vec![whycode_core::TodoItem::new(
+                    "a",
+                    "panel item",
+                    whycode_core::TodoStatus::InProgress,
+                )],
+            },
+        );
+        assert_eq!(app.todos.len(), 1);
+        assert_eq!(app.todos[0].content, "panel item");
+
+        apply_turn_event(
+            &mut app,
+            TurnEvent::ToolStart {
+                id: "tw".into(),
+                name: "todowrite".into(),
+                input: serde_json::json!({
+                    "todos":[{"id":"a","content":"updated","status":"completed"}]
+                }),
+            },
+        );
+        assert_eq!(app.todos[0].status, whycode_core::TodoStatus::Completed);
+        apply_turn_event(
+            &mut app,
+            TurnEvent::ToolStart {
+                id: "tw2".into(),
+                name: "todo".into(),
+                input: serde_json::json!({
+                    "merge": false,
+                    "todos":[{"id":"z","content":"only","status":"pending"}]
+                }),
+            },
+        );
+        assert_eq!(app.todos.len(), 1);
+        assert_eq!(app.todos[0].id, "z");
     }
 
     #[test]
@@ -6434,7 +6464,8 @@ mod tests {
             },
         );
         refresh_sidebar(&mut app, &config, &idx);
-        assert!(app.sidebar.todos.iter().any(|t| t.contains("do it")));
+        load_app_todos(&mut app);
+        assert!(app.todos.iter().any(|t| t.content == "do it"));
         assert!(app.sidebar.mcp_status.iter().any(|s| s.contains("demo")));
 
         let rt = test_runtime();

--- a/crates/tui/src/session_runtime.rs
+++ b/crates/tui/src/session_runtime.rs
@@ -98,6 +98,8 @@ pub struct ViewSnapshot {
     pub turn_usage: Option<whycode_core::types::Usage>,
     pub context_used: u64,
     pub pending_suggestion: Option<String>,
+    pub session_id: String,
+    pub todos: Vec<whycode_core::TodoItem>,
 }
 
 impl Default for ViewSnapshot {
@@ -118,6 +120,8 @@ impl Default for ViewSnapshot {
             turn_usage: None,
             context_used: 0,
             pending_suggestion: None,
+            session_id: String::new(),
+            todos: Vec::new(),
         }
     }
 }

--- a/crates/tui/src/ui/mod.rs
+++ b/crates/tui/src/ui/mod.rs
@@ -18,5 +18,6 @@ pub mod status_bar;
 pub mod subagents;
 pub mod timefmt;
 pub mod toast;
+pub mod todos;
 
 pub use render::render;

--- a/crates/tui/src/ui/render.rs
+++ b/crates/tui/src/ui/render.rs
@@ -24,6 +24,7 @@ use super::slash_suggest;
 use super::status;
 use super::subagents;
 use super::toast;
+use super::todos;
 
 const SPINNER: &[&str] = &["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
@@ -223,17 +224,44 @@ fn render_shell(frame: &mut Frame, app: &mut TuiApp, palette: &ThemePalette) {
     status::render_footer(frame, outer[2], app, palette);
 
     let strip_h = subagents::strip_height(app);
-    let (strip, body) = if strip_h > 0 {
+    let todo_h = todos::panel_height(app, body.height.saturating_sub(strip_h));
+    let (strip, todo_area, body) = if strip_h == 0 && todo_h == 0 {
+        (None, None, body)
+    } else {
+        let mut constraints = Vec::new();
+        if strip_h > 0 {
+            constraints.push(Constraint::Length(strip_h));
+        }
+        if todo_h > 0 {
+            constraints.push(Constraint::Length(todo_h));
+        }
+        constraints.push(Constraint::Min(3));
         let chunks = Layout::default()
             .direction(Direction::Vertical)
-            .constraints([Constraint::Length(strip_h), Constraint::Min(3)])
+            .constraints(constraints)
             .split(body);
-        (Some(chunks[0]), chunks[1])
-    } else {
-        (None, body)
+        let mut i = 0;
+        let strip = if strip_h > 0 {
+            let a = chunks[i];
+            i += 1;
+            Some(a)
+        } else {
+            None
+        };
+        let todo_area = if todo_h > 0 {
+            let a = chunks[i];
+            i += 1;
+            Some(a)
+        } else {
+            None
+        };
+        (strip, todo_area, chunks[i])
     };
     if let Some(area) = strip {
         subagents::render_strip(frame, area, app, palette);
+    }
+    if let Some(area) = todo_area {
+        todos::render_panel(frame, area, app, palette);
     }
 
     if app.messages.is_empty() {

--- a/crates/tui/src/ui/sidebar.rs
+++ b/crates/tui/src/ui/sidebar.rs
@@ -146,20 +146,16 @@ fn render_mcp(frame: &mut Frame, area: Rect, app: &TuiApp, palette: &ThemePalett
 }
 
 fn render_todos(frame: &mut Frame, area: Rect, app: &TuiApp, palette: &ThemePalette) {
-    let sidebar = &app.sidebar;
     let mut lines: Vec<Line> = Vec::new();
 
-    if sidebar.todos.is_empty() {
+    if app.todos.is_empty() {
         lines.push(Line::from(Span::styled(
             " No TODOs ",
             Style::default().fg(palette.dim),
         )));
     } else {
-        for todo in &sidebar.todos {
-            lines.push(Line::from(Span::styled(
-                format!(" {todo}"),
-                Style::default().fg(palette.fg),
-            )));
+        for item in &app.todos {
+            lines.push(super::todos::item_line(item, palette));
         }
     }
 
@@ -363,7 +359,10 @@ mod tests {
         assert!(text.contains("No TODOs"), "{text}");
 
         let mut app = app_with_tab(SidebarTab::Todos);
-        app.sidebar.todos = vec!["☐ first".into(), "☑ done".into()];
+        app.todos = vec![
+            whycode_core::TodoItem::new("a", "first", whycode_core::TodoStatus::Pending),
+            whycode_core::TodoItem::new("b", "done", whycode_core::TodoStatus::Completed),
+        ];
         let palette = app.config.palette();
         let text = paint(60, 12, |f| render(f, f.area(), &app, &palette));
         assert!(text.contains("☐ first"), "{text}");

--- a/crates/tui/src/ui/todos.rs
+++ b/crates/tui/src/ui/todos.rs
@@ -1,0 +1,197 @@
+//! Sticky todo panel under the header (Grok Build-style).
+
+use crate::app::TuiApp;
+use crate::theme::ThemePalette;
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span, Text},
+    widgets::Paragraph,
+};
+use whycode_core::todo::{TodoItem, TodoStatus, all_terminal, terminal_count};
+
+/// Max item rows (not counting the header or overflow line).
+pub const MAX_ITEMS: usize = 8;
+
+/// Rows reserved under the header/subagent strip when todos exist.
+pub fn panel_height(app: &TuiApp, body_h: u16) -> u16 {
+    if app.todos.is_empty() {
+        return 0;
+    }
+    let max = body_h.saturating_sub(3);
+    if max == 0 {
+        return 0;
+    }
+    let want = if all_terminal(&app.todos) {
+        1
+    } else {
+        let shown = app.todos.len().min(MAX_ITEMS);
+        let extra = usize::from(app.todos.len() > MAX_ITEMS);
+        (1 + shown + extra) as u16
+    };
+    want.min(max)
+}
+
+pub fn status_style(status: TodoStatus, palette: &ThemePalette) -> Style {
+    match status {
+        TodoStatus::Pending => Style::default().fg(palette.fg),
+        TodoStatus::InProgress => Style::default()
+            .fg(palette.accent)
+            .add_modifier(Modifier::BOLD),
+        TodoStatus::Completed => Style::default()
+            .fg(palette.success)
+            .add_modifier(Modifier::DIM),
+        TodoStatus::Cancelled => Style::default().fg(palette.dim),
+    }
+}
+
+pub fn item_line(item: &TodoItem, palette: &ThemePalette) -> Line<'static> {
+    Line::from(Span::styled(
+        format!(" {} {}", item.status.mark(), item.content),
+        status_style(item.status, palette),
+    ))
+}
+
+pub fn render_panel(frame: &mut Frame, area: Rect, app: &TuiApp, palette: &ThemePalette) {
+    if area.height == 0 || app.todos.is_empty() {
+        return;
+    }
+    let total = app.todos.len();
+    let done = terminal_count(&app.todos);
+    let collapsed = all_terminal(&app.todos) || area.height == 1;
+
+    let mut lines: Vec<Line> = Vec::new();
+    let header = if collapsed && all_terminal(&app.todos) {
+        format!(" Todos  {done}/{total} done")
+    } else {
+        format!(" Todos  {done}/{total}")
+    };
+    lines.push(Line::from(Span::styled(
+        header,
+        Style::default()
+            .fg(if collapsed && all_terminal(&app.todos) {
+                palette.success
+            } else {
+                palette.accent
+            })
+            .add_modifier(Modifier::BOLD),
+    )));
+
+    if !collapsed {
+        let mut budget = area.height.saturating_sub(1) as usize;
+        let overflow = app.todos.len() > MAX_ITEMS.min(budget);
+        if overflow {
+            budget = budget.saturating_sub(1);
+        }
+        let take = budget.min(MAX_ITEMS).min(app.todos.len());
+        for item in app.todos.iter().take(take) {
+            lines.push(item_line(item, palette));
+        }
+        let hidden = app.todos.len().saturating_sub(take);
+        if hidden > 0 {
+            lines.push(Line::from(Span::styled(
+                format!(" … +{hidden} more"),
+                Style::default().fg(palette.dim),
+            )));
+        }
+    }
+
+    frame.render_widget(
+        Paragraph::new(Text::from(lines)).style(Style::default().bg(palette.status_bar_bg)),
+        area,
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::TuiAppConfig;
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+    use whycode_core::todo::{TodoItem, TodoStatus};
+
+    fn paint(app: &TuiApp, w: u16, h: u16) -> String {
+        let palette = app.config.palette();
+        let backend = TestBackend::new(w, h);
+        let mut terminal = Terminal::new(backend).expect("term");
+        terminal
+            .draw(|f| render_panel(f, f.area(), app, &palette))
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        let mut out = String::new();
+        for y in 0..buf.area().height {
+            for x in 0..buf.area().width {
+                if let Some(c) = buf.cell((x, y)) {
+                    out.push_str(c.symbol());
+                }
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    fn item(id: &str, content: &str, status: TodoStatus) -> TodoItem {
+        TodoItem::new(id, content, status)
+    }
+
+    #[test]
+    fn hidden_when_empty() {
+        let app = TuiApp::new(TuiAppConfig::default());
+        assert_eq!(panel_height(&app, 24), 0);
+        let text = paint(&app, 40, 2);
+        assert!(!text.contains("Todos"), "{text}");
+    }
+
+    #[test]
+    fn shows_marks_and_counts() {
+        let mut app = TuiApp::new(TuiAppConfig::default());
+        app.todos = vec![
+            item("a", "pending one", TodoStatus::Pending),
+            item("b", "working now", TodoStatus::InProgress),
+            item("c", "done item", TodoStatus::Completed),
+            item("d", "skipped", TodoStatus::Cancelled),
+        ];
+        assert_eq!(panel_height(&app, 24), 5);
+        let text = paint(&app, 60, 6);
+        assert!(text.contains("Todos  2/4"), "{text}");
+        assert!(text.contains("☐ pending one"), "{text}");
+        assert!(text.contains("▶ working now"), "{text}");
+        assert!(text.contains("☑ done item"), "{text}");
+        assert!(text.contains("✗ skipped"), "{text}");
+    }
+
+    #[test]
+    fn all_done_collapses() {
+        let mut app = TuiApp::new(TuiAppConfig::default());
+        app.todos = vec![
+            item("a", "one", TodoStatus::Completed),
+            item("b", "two", TodoStatus::Cancelled),
+        ];
+        assert_eq!(panel_height(&app, 24), 1);
+        let text = paint(&app, 40, 1);
+        assert!(text.contains("Todos  2/2 done"), "{text}");
+        assert!(!text.contains("☐"), "{text}");
+    }
+
+    #[test]
+    fn overflow_line_when_many() {
+        let mut app = TuiApp::new(TuiAppConfig::default());
+        app.todos = (0..10)
+            .map(|i| item(&i.to_string(), &format!("item {i}"), TodoStatus::Pending))
+            .collect();
+        assert_eq!(panel_height(&app, 24), 10); // header + 8 + overflow
+        let text = paint(&app, 40, 12);
+        assert!(text.contains("+2 more"), "{text}");
+        assert!(text.contains("item 0"), "{text}");
+        assert!(!text.contains("item 9"), "{text}");
+    }
+
+    #[test]
+    fn tiny_body_hides_panel() {
+        let mut app = TuiApp::new(TuiAppConfig::default());
+        app.todos = vec![item("a", "x", TodoStatus::Pending)];
+        assert_eq!(panel_height(&app, 3), 0);
+        assert_eq!(panel_height(&app, 0), 0);
+    }
+}

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -112,6 +112,7 @@ Contributors checking a TUI change on Alacritty / Kitty / WezTerm / VTE: see
 | `:` | Command mode (`:theme`, `:q`, …) |
 | `Ctrl+P` / `Ctrl+M` | Provider setup / model selection |
 | `Ctrl+B` | Toggle sidebar (Files / Diag / MCP / Todos / View) |
+| — | Todo list from `todowrite` appears under the header (live, color-coded) |
 | `[` / `]` | Cycle sidebar tabs (scrollback focus) |
 | `Ctrl+C` / `Ctrl+Q` | Clear draft or quit |
 


### PR DESCRIPTION
Fixes #24

## What
Grok Build–style todo list, live under the TUI header:

- Color-coded `pending` / `in_progress` / `completed` / `cancelled`
- Auto-shown when the session has todos; collapses to `N/N done` when finished
- Session-scoped storage (`.whycode/todos/<session_id>.json`)
- `todowrite` `merge` defaults to **true**
- Live `TurnEvent::Todos` (plus optimistic ToolStart)
- Build/plan prompts tell the model to use `todowrite`

`Ctrl+T` stays agent cycle. `Ctrl+G` stays the subagent tasks pane.

## Tests
- `cargo test -p whycode-core --lib`
- `cargo test -p whycode-tools --lib`
- TUI todo panel + `apply_turn_event` + sidebar
- clippy `-D warnings`, fmt, panic/swallowed-error/dependency budgets