### PR TITLE
feat: clarification policy, Antigravity provider, and related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 .env
 .env.*
 !.env.example
+
+# Claude/local agent worktrees
+.claude/

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1922,8 +1922,8 @@ impl Agent {
             }
         }
 
-        // Intent authorization (Claude-style): question/plan turns must not
-        // silently mutate. Runs after blast-radius risk, before permission map.
+        // Intent authorization (Claude-style): question/plan/ambiguous-always
+        // turns must not silently mutate. After blast-radius, before permission.
         if let Some(intent) = turn_intent {
             let command = tc.arguments.get("command").and_then(|v| v.as_str());
             match crate::intent::authorize_tool(

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -1033,7 +1033,7 @@ impl Agent {
             .get(provider_name)
             .ok_or_else(|| {
                 whycode_core::Error::Llm(format!(
-                    "Unknown provider: {}. Available: anthropic, openai, google, and configured custom providers",
+                    "Unknown provider: {}. Available: anthropic, openai, google, google-antigravity, and configured custom providers",
                     provider_name
                 ))
             })?;

--- a/crates/agent/src/behavior_eval.rs
+++ b/crates/agent/src/behavior_eval.rs
@@ -1,0 +1,506 @@
+//! Deterministic semantic-policy regression corpus.
+//!
+//! This is deliberately not a live-model benchmark: each scenario checks an
+//! objective intent and authorization contract without network or prose
+//! snapshots. Live providers can reuse the same scenario metadata later.
+
+use crate::intent::{
+    IntentGuidanceMode, ToolAuthDecision, UserIntent, authorize_tool, classify_user_intent,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExpectedToolDecision {
+    Allow,
+    Confirm,
+    Refuse,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct BehaviorScenario {
+    name: &'static str,
+    group: &'static str,
+    user_message: &'static str,
+    expected_intent: UserIntent,
+    agent_name: &'static str,
+    tool_name: &'static str,
+    command: Option<&'static str>,
+    guidance: IntentGuidanceMode,
+    expected_tool_decision: ExpectedToolDecision,
+}
+
+fn evaluate_scenario(scenario: &BehaviorScenario) -> (UserIntent, ExpectedToolDecision) {
+    let assessment = classify_user_intent(scenario.user_message);
+    let decision = authorize_tool(
+        &assessment,
+        scenario.agent_name,
+        scenario.tool_name,
+        scenario.command,
+        scenario.guidance,
+    );
+    let decision = match decision {
+        ToolAuthDecision::Allow => ExpectedToolDecision::Allow,
+        ToolAuthDecision::Confirm { .. } => ExpectedToolDecision::Confirm,
+        ToolAuthDecision::Refuse { .. } => ExpectedToolDecision::Refuse,
+    };
+    (assessment.intent, decision)
+}
+
+macro_rules! case {
+    ($name:literal, $group:literal, $message:literal, $intent:ident, $agent:literal, $tool:literal, $command:expr, $decision:ident) => {
+        BehaviorScenario {
+            name: $name,
+            group: $group,
+            user_message: $message,
+            expected_intent: UserIntent::$intent,
+            agent_name: $agent,
+            tool_name: $tool,
+            command: $command,
+            guidance: IntentGuidanceMode::Auto,
+            expected_tool_decision: ExpectedToolDecision::$decision,
+        }
+    };
+    ($name:literal, $group:literal, $message:literal, $intent:ident, $agent:literal, $tool:literal, $command:expr, $guidance:ident, $decision:ident) => {
+        BehaviorScenario {
+            name: $name,
+            group: $group,
+            user_message: $message,
+            expected_intent: UserIntent::$intent,
+            agent_name: $agent,
+            tool_name: $tool,
+            command: $command,
+            guidance: IntentGuidanceMode::$guidance,
+            expected_tool_decision: ExpectedToolDecision::$decision,
+        }
+    };
+}
+
+const SCENARIOS: &[BehaviorScenario] = &[
+    // Questions: explain without silently mutating.
+    case!(
+        "question_en_how",
+        "intent_question",
+        "How does session compaction work?",
+        Question,
+        "build",
+        "read",
+        None,
+        Allow
+    ),
+    case!(
+        "question_en_why",
+        "intent_question",
+        "Why does the auth refresh fail?",
+        Question,
+        "build",
+        "edit",
+        None,
+        Confirm
+    ),
+    case!(
+        "question_en_explain",
+        "intent_question",
+        "Explain the provider fallback chain",
+        Question,
+        "build",
+        "grep",
+        None,
+        Allow
+    ),
+    case!(
+        "question_en_where",
+        "intent_question",
+        "Where is prompt caching configured?",
+        Question,
+        "build",
+        "write",
+        None,
+        Confirm
+    ),
+    case!(
+        "question_tr_how",
+        "intent_question",
+        "Compaction nasıl çalışıyor?",
+        Question,
+        "build",
+        "read",
+        None,
+        Allow
+    ),
+    case!(
+        "question_tr_explain",
+        "intent_question",
+        "Kimlik doğrulamayı açıkla",
+        Question,
+        "build",
+        "bash",
+        Some("git status"),
+        Allow
+    ),
+    case!(
+        "question_change_shape",
+        "intent_question",
+        "Can we fix the flaky test?",
+        Question,
+        "build",
+        "edit",
+        None,
+        Confirm
+    ),
+    case!(
+        "question_shell_mutation",
+        "intent_question",
+        "How does cleanup work?",
+        Question,
+        "build",
+        "bash",
+        Some("rm -rf target/tmp"),
+        Confirm
+    ),
+    // Changes: explicit implementation requests authorize normal mutations.
+    case!(
+        "change_en_fix",
+        "intent_change",
+        "Fix the auth bug in session.rs",
+        Change,
+        "build",
+        "edit",
+        None,
+        Allow
+    ),
+    case!(
+        "change_en_add",
+        "intent_change",
+        "Add a timeout to the provider request",
+        Change,
+        "build",
+        "write",
+        None,
+        Allow
+    ),
+    case!(
+        "change_en_refactor",
+        "intent_change",
+        "Refactor the retry loop",
+        Change,
+        "build",
+        "bash",
+        Some("cargo test -p whycode-agent"),
+        Allow
+    ),
+    case!(
+        "change_en_update",
+        "intent_change",
+        "Update the README example",
+        Change,
+        "build",
+        "edit",
+        None,
+        Allow
+    ),
+    case!(
+        "change_tr_fix",
+        "intent_change",
+        "Auth bug'ını düzelt",
+        Change,
+        "build",
+        "edit",
+        None,
+        Allow
+    ),
+    case!(
+        "change_tr_add",
+        "intent_change",
+        "Provider testini ekle",
+        Change,
+        "build",
+        "write",
+        None,
+        Allow
+    ),
+    case!(
+        "change_tr_update",
+        "intent_change",
+        "Bağımlılıkları güncelle",
+        Change,
+        "build",
+        "bash",
+        Some("cargo metadata --no-deps"),
+        Allow
+    ),
+    case!(
+        "change_read",
+        "intent_change",
+        "Implement request tracing",
+        Change,
+        "build",
+        "read",
+        None,
+        Allow
+    ),
+    // Plans: research is allowed; implementation needs confirmation in build.
+    case!(
+        "plan_en_architecture",
+        "intent_plan",
+        "Design the architecture and write a plan",
+        Plan,
+        "build",
+        "read",
+        None,
+        Allow
+    ),
+    case!(
+        "plan_en_roadmap",
+        "intent_plan",
+        "Create a roadmap for provider parity",
+        Plan,
+        "build",
+        "edit",
+        None,
+        Confirm
+    ),
+    case!(
+        "plan_en_approach",
+        "intent_plan",
+        "What's the best approach for session resume?",
+        Plan,
+        "build",
+        "grep",
+        None,
+        Allow
+    ),
+    case!(
+        "plan_en_before",
+        "intent_plan",
+        "Before we implement, propose an approach",
+        Plan,
+        "build",
+        "write",
+        None,
+        Confirm
+    ),
+    case!(
+        "plan_tr",
+        "intent_plan",
+        "Mimariyi planla ve bir yol haritası çıkar",
+        Plan,
+        "build",
+        "edit",
+        None,
+        Confirm
+    ),
+    case!(
+        "plan_tr_strategy",
+        "intent_plan",
+        "Provider geçişi için strateji planla",
+        Plan,
+        "build",
+        "read",
+        None,
+        Allow
+    ),
+    case!(
+        "plan_readonly_agent",
+        "intent_plan",
+        "Write a migration plan",
+        Plan,
+        "plan",
+        "write",
+        None,
+        Refuse
+    ),
+    case!(
+        "plan_shell_read",
+        "intent_plan",
+        "Plan the dependency cleanup",
+        Plan,
+        "build",
+        "bash",
+        Some("git diff --stat"),
+        Allow
+    ),
+    // Mode and guidance contracts.
+    case!(
+        "ask_refuses_change",
+        "authorization",
+        "Fix the login bug",
+        Change,
+        "ask",
+        "edit",
+        None,
+        Refuse
+    ),
+    case!(
+        "explore_refuses_change",
+        "authorization",
+        "Add request logging",
+        Change,
+        "explore",
+        "write",
+        None,
+        Refuse
+    ),
+    case!(
+        "plan_refuses_change",
+        "authorization",
+        "Implement token refresh",
+        Change,
+        "plan",
+        "bash",
+        Some("cargo test"),
+        Refuse
+    ),
+    case!(
+        "readonly_tool_any_mode",
+        "authorization",
+        "Fix the parser",
+        Change,
+        "ask",
+        "read",
+        None,
+        Allow
+    ),
+    case!(
+        "guidance_off_question",
+        "authorization",
+        "How does auth work?",
+        Question,
+        "build",
+        "edit",
+        None,
+        Off,
+        Allow
+    ),
+    case!(
+        "guidance_always_ambiguous",
+        "authorization",
+        "auth maybe",
+        Ambiguous,
+        "build",
+        "write",
+        None,
+        Always,
+        Confirm
+    ),
+    case!(
+        "ambiguous_read",
+        "authorization",
+        "auth maybe",
+        Ambiguous,
+        "build",
+        "read",
+        None,
+        Allow
+    ),
+    case!(
+        "trivial_read",
+        "authorization",
+        "selam",
+        Trivial,
+        "build",
+        "read",
+        None,
+        Allow
+    ),
+];
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct EvalMetrics {
+    total: usize,
+    intent_matches: usize,
+    authorization_matches: usize,
+    passed: usize,
+}
+
+struct EvalReport {
+    metrics: EvalMetrics,
+    failures: Vec<String>,
+    groups: std::collections::BTreeSet<&'static str>,
+}
+
+fn evaluate_corpus(scenarios: &[BehaviorScenario]) -> EvalReport {
+    let mut metrics = EvalMetrics::default();
+    let mut failures = Vec::new();
+    let mut groups = std::collections::BTreeSet::new();
+
+    for scenario in scenarios {
+        metrics.total += 1;
+        groups.insert(scenario.group);
+        let (actual_intent, actual_decision) = evaluate_scenario(scenario);
+        let intent_ok = actual_intent == scenario.expected_intent;
+        let authorization_ok = actual_decision == scenario.expected_tool_decision;
+        metrics.intent_matches += usize::from(intent_ok);
+        metrics.authorization_matches += usize::from(authorization_ok);
+        metrics.passed += usize::from(intent_ok && authorization_ok);
+
+        if !intent_ok || !authorization_ok {
+            failures.push(format!(
+                "{} [{}]: intent={actual_intent:?} expected={:?}; authorization={actual_decision:?} expected={:?}",
+                scenario.name,
+                scenario.group,
+                scenario.expected_intent,
+                scenario.expected_tool_decision,
+            ));
+        }
+    }
+
+    EvalReport {
+        metrics,
+        failures,
+        groups,
+    }
+}
+
+#[test]
+fn semantic_policy_corpus_is_valid() {
+    assert!(SCENARIOS.len() >= 30, "semantic corpus unexpectedly shrank");
+
+    let mut names = std::collections::BTreeSet::new();
+    for scenario in SCENARIOS {
+        assert!(
+            names.insert(scenario.name),
+            "duplicate scenario name: {}",
+            scenario.name
+        );
+    }
+
+    let report = evaluate_corpus(SCENARIOS);
+    assert!(
+        report.groups.len() >= 4,
+        "semantic corpus needs multiple independent policy groups"
+    );
+}
+
+#[test]
+fn semantic_policy_baseline_is_explicit() {
+    let report = evaluate_corpus(SCENARIOS);
+
+    // Phase 1 freezes the measured pre-policy-change baseline. Phase 2 must
+    // improve these explicit shortfalls rather than silently weakening the
+    // desired scenario contracts above.
+    assert_eq!(
+        report.metrics,
+        EvalMetrics {
+            total: 32,
+            intent_matches: 29,
+            authorization_matches: 28,
+            passed: 26,
+        },
+        "semantic baseline changed; review every changed scenario:\n{}",
+        report.failures.join("\n")
+    );
+    assert_eq!(report.failures.len(), 6);
+}
+
+#[test]
+#[ignore = "desired contract ratchet; enable after clarification policy is implemented"]
+fn semantic_policy_corpus_meets_desired_contract() {
+    let report = evaluate_corpus(SCENARIOS);
+    assert_eq!(
+        report.metrics.passed,
+        report.metrics.total,
+        "scenario pass rate {}/{}; failures:\n{}",
+        report.metrics.passed,
+        report.metrics.total,
+        report.failures.join("\n")
+    );
+}

--- a/crates/agent/src/behavior_eval.rs
+++ b/crates/agent/src/behavior_eval.rs
@@ -474,25 +474,23 @@ fn semantic_policy_corpus_is_valid() {
 fn semantic_policy_baseline_is_explicit() {
     let report = evaluate_corpus(SCENARIOS);
 
-    // Phase 1 freezes the measured pre-policy-change baseline. Phase 2 must
-    // improve these explicit shortfalls rather than silently weakening the
-    // desired scenario contracts above.
+    // Clarification policy: plan/question turns do not silently mutate, and
+    // plan-shaped asks (roadmap, best approach, write a plan) classify as Plan.
     assert_eq!(
         report.metrics,
         EvalMetrics {
             total: 32,
-            intent_matches: 29,
-            authorization_matches: 28,
-            passed: 26,
+            intent_matches: 32,
+            authorization_matches: 32,
+            passed: 32,
         },
         "semantic baseline changed; review every changed scenario:\n{}",
         report.failures.join("\n")
     );
-    assert_eq!(report.failures.len(), 6);
+    assert!(report.failures.is_empty(), "{}", report.failures.join("\n"));
 }
 
 #[test]
-#[ignore = "desired contract ratchet; enable after clarification policy is implemented"]
 fn semantic_policy_corpus_meets_desired_contract() {
     let report = evaluate_corpus(SCENARIOS);
     assert_eq!(

--- a/crates/agent/src/intent.rs
+++ b/crates/agent/src/intent.rs
@@ -132,13 +132,26 @@ pub fn classify_user_intent(text: &str) -> IntentAssessment {
         + if has_qmark { 1.2 } else { 0.0 }
         + if starts_question { 1.0 } else { 0.0 };
     let c = c_score as f32 + if imperative { 1.4 } else { 0.0 };
-    let p = p_score as f32 + if sprawl && p_score > 0 { 0.8 } else { 0.0 };
+    let mut p = p_score as f32 + if sprawl && p_score > 0 { 0.8 } else { 0.0 };
 
     // "can we fix" / "shall we" — question form about a change: treat as
     // clarification-first (Claude auto-mode: not a hard directive).
     if has_qmark && c_score > 0 && q_score == 0 {
         q += 0.8;
         reasons.push("question_about_change");
+    }
+
+    // "create a roadmap" / "write a plan": create/write describe the plan
+    // document, not an implementation request.
+    if p_score > 0 && c_score > 0 {
+        p += 1.6;
+        reasons.push("plan_artifact");
+    }
+
+    // "what's the best approach?" is planning, not a mere explanation.
+    if p_score > 0 && (has_qmark || starts_question) {
+        p += 1.4;
+        reasons.push("planning_question");
     }
 
     // Pure explain requests without fix verbs.
@@ -535,9 +548,12 @@ fn shell_head_readonly_ok(command: &str) -> bool {
 ///
 /// - **ask/plan agents**: mutating tools should already be denied by permission;
 ///   this is a second line of defence.
-/// - **build + Question/Plan (high)**: escalate mutators to Confirm so the model
+/// - **build + Question (high)**: escalate mutators to Confirm so the model
 ///   cannot silently implement a question.
-/// - **Change / Ambiguous / Off mode**: allow (shell risk gate still applies).
+/// - **build + Plan (any confidence)**: escalate mutators — a plan request is
+///   not permission to start implementation.
+/// - **Always guidance + Ambiguous**: confirm mutating tools.
+/// - **Change / Auto Ambiguous / Off mode**: allow (shell risk gate still applies).
 pub fn authorize_tool(
     assessment: &IntentAssessment,
     agent_name: &str,
@@ -571,21 +587,15 @@ pub fn authorize_tool(
         };
     }
 
-    // Only escalate when we are confident the user did not authorize mutation.
+    // Escalate when the user did not clearly authorize mutation.
     let escalate = match assessment.intent {
         UserIntent::Question
             if assessment.is_high() || matches!(guidance, IntentGuidanceMode::Always) =>
         {
             Some("question")
         }
-        UserIntent::Plan
-            if assessment.is_high() || matches!(guidance, IntentGuidanceMode::Always) =>
-        {
-            Some("plan")
-        }
-        UserIntent::Ambiguous
-            if matches!(guidance, IntentGuidanceMode::Always) && assessment.confidence >= 0.4 =>
-        {
+        UserIntent::Plan => Some("plan"),
+        UserIntent::Ambiguous if matches!(guidance, IntentGuidanceMode::Always) => {
             Some("ambiguous")
         }
         _ => None,
@@ -755,6 +765,8 @@ const PLAN_MARKERS: &[&str] = &[
     "planla",
     "plan çıkar",
     "plan cikar",
+    "yol haritası",
+    "yol haritasi",
     "mimari",
     "nasıl ilerleyelim",
     "nasil ilerleyelim",
@@ -849,6 +861,24 @@ mod tests {
             matches!(a.intent, UserIntent::Question | UserIntent::Ambiguous),
             "expected question-ish, got {a:?}"
         );
+    }
+
+    #[test]
+    fn create_roadmap_is_plan_not_change() {
+        let a = classify_user_intent("Create a roadmap for provider parity");
+        assert_eq!(a.intent, UserIntent::Plan, "{a:?}");
+    }
+
+    #[test]
+    fn best_approach_question_is_plan() {
+        let a = classify_user_intent("What's the best approach for session resume?");
+        assert_eq!(a.intent, UserIntent::Plan, "{a:?}");
+    }
+
+    #[test]
+    fn write_migration_plan_is_plan() {
+        let a = classify_user_intent("Write a migration plan");
+        assert_eq!(a.intent, UserIntent::Plan, "{a:?}");
     }
 
     #[test]
@@ -1012,5 +1042,27 @@ mod tests {
         let a = classify_user_intent("How does auth work?");
         let d = authorize_tool(&a, "build", "edit", None, IntentGuidanceMode::Off);
         assert_eq!(d, ToolAuthDecision::Allow);
+    }
+
+    #[test]
+    fn authorize_confirms_plan_write_without_high_confidence() {
+        let a = IntentAssessment {
+            intent: UserIntent::Plan,
+            confidence: 0.5,
+            reasons: vec!["plan_marker"],
+        };
+        let d = authorize_tool(&a, "build", "write", None, IntentGuidanceMode::Auto);
+        assert!(matches!(d, ToolAuthDecision::Confirm { .. }), "{d:?}");
+    }
+
+    #[test]
+    fn authorize_always_confirms_ambiguous_write() {
+        let a = IntentAssessment {
+            intent: UserIntent::Ambiguous,
+            confidence: 0.35,
+            reasons: vec![],
+        };
+        let d = authorize_tool(&a, "build", "write", None, IntentGuidanceMode::Always);
+        assert!(matches!(d, ToolAuthDecision::Confirm { .. }), "{d:?}");
     }
 }

--- a/crates/agent/src/lib.rs
+++ b/crates/agent/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod agent;
 pub mod background;
+#[cfg(test)]
+mod behavior_eval;
 pub mod events;
 pub mod intent;
 pub mod mcp_load;

--- a/crates/agent/src/subagent.rs
+++ b/crates/agent/src/subagent.rs
@@ -240,7 +240,7 @@ impl SubagentRunner {
 
         let provider = self.provider_registry.get(provider_name).ok_or_else(|| {
             whycode_core::Error::Llm(format!(
-                "Unknown provider: {}. Available: anthropic, openai, google",
+                "Unknown provider: {}. Available: anthropic, openai, google, google-antigravity",
                 provider_name
             ))
         })?;

--- a/crates/agent/src/title.rs
+++ b/crates/agent/src/title.rs
@@ -48,7 +48,7 @@ fn small_model_for(provider: &str, model: &str) -> Option<&'static str> {
         "anthropic" => Some("claude-haiku-4-5-20251001"),
         "openai" => Some("gpt-4o-mini"),
         "google" => Some("gemini-2.0-flash"),
-        "google-antigravity" => Some("gemini-3.1-flash"),
+        "google-antigravity" => Some("gemini-3.5-flash-low"),
         "xai" => Some("grok-3-mini"),
         "groq" => Some("llama-3.1-8b-instant"),
         "mistral" => Some("mistral-small-latest"),

--- a/crates/agent/src/title.rs
+++ b/crates/agent/src/title.rs
@@ -48,6 +48,7 @@ fn small_model_for(provider: &str, model: &str) -> Option<&'static str> {
         "anthropic" => Some("claude-haiku-4-5-20251001"),
         "openai" => Some("gpt-4o-mini"),
         "google" => Some("gemini-2.0-flash"),
+        "google-antigravity" => Some("gemini-3.1-flash"),
         "xai" => Some("grok-3-mini"),
         "groq" => Some("llama-3.1-8b-instant"),
         "mistral" => Some("mistral-small-latest"),

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -106,38 +106,58 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
         return Ok(token);
     }
 
-    // 2. Not onboarded: pick the free/managed tier and run onboardUser,
-    // polling the long-running operation until it yields a project id.
+    // 2. Not onboarded: run onboardUser on the allowed tier and poll the
+    // long-running operation until it yields a project id. Provisioning can
+    // take a couple of minutes (project creation server-side), so poll well
+    // past a few seconds — bailing early surfaces as "no project id".
     let tier = pick_tier(&load);
-    let onboard = post(
-        ":onboardUser",
-        &token.access_token,
-        &json!({ "tierId": tier, "metadata": client_metadata() }),
-    )
-    .await?;
+    let mut body = json!({ "tierId": tier, "metadata": client_metadata() });
+    // Tiers flagged `userDefinedCloudaicompanionProject` (standard-tier for
+    // Pro accounts) expect the caller's own Cloud project in this field —
+    // same shape Gemini CLI sends. Harmless when absent.
+    if let Some(project) = explicit_project(&token) {
+        body["cloudaicompanionProject"] = Value::String(project);
+    }
+    let onboard = post(":onboardUser", &token.access_token, &body).await?;
     let mut operation = onboard;
-    for _ in 0..10 {
+    for _ in 0..60 {
         if operation["done"].as_bool().unwrap_or(false) {
             break;
         }
         let Some(name) = operation["name"].as_str().map(str::to_string) else {
             break;
         };
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
         operation = post(&format!("/{name}"), &token.access_token, &json!({})).await?;
     }
 
-    match operation["response"]["cloudaicompanionProject"]["id"].as_str() {
+    match yielded_project(&operation) {
         Some(id) => {
             token
                 .extra
-                .insert(PROJECT_ID_KEY.to_string(), Value::String(id.to_string()));
+                .insert(PROJECT_ID_KEY.to_string(), Value::String(id));
             Ok(token)
         }
-        None => Err(AuthError::Provider(
-            "Code Assist onboarding did not yield a project id".into(),
-        )),
+        None => {
+            let done = operation["done"].as_bool().unwrap_or(false);
+            Err(AuthError::Provider(format!(
+                "Code Assist onboarding did not yield a project id \
+                 (operation done={done}, tier={tier}) — set GOOGLE_CLOUD_PROJECT \
+                 to your Cloud project id and retry"
+            )))
+        }
     }
+}
+
+/// Pull the provisioned project id out of a finished `onboardUser` LRO.
+/// The service has shipped both shapes: an object (`{"id": …}`) and a bare
+/// project-id string, so accept either.
+fn yielded_project(operation: &Value) -> Option<String> {
+    let proj = &operation["response"]["cloudaicompanionProject"];
+    if let Some(id) = proj["id"].as_str().filter(|s| !s.is_empty()) {
+        return Some(id.to_string());
+    }
+    proj.as_str().filter(|s| !s.is_empty()).map(str::to_string)
 }
 
 /// The tier to pass to `onboardUser`, from the `allowedTiers` the account
@@ -204,5 +224,26 @@ mod tests {
 
         let empty = json!({});
         assert_eq!(pick_tier(&empty), "free-tier");
+    }
+
+    #[test]
+    fn yielded_project_reads_object_and_string_shapes() {
+        let object = json!({
+            "done": true,
+            "response": {"cloudaicompanionProject": {"id": "gen-lang-client-123"}}
+        });
+        assert_eq!(
+            yielded_project(&object).as_deref(),
+            Some("gen-lang-client-123")
+        );
+
+        let plain = json!({
+            "done": true,
+            "response": {"cloudaicompanionProject": "my-project-456"}
+        });
+        assert_eq!(yielded_project(&plain).as_deref(), Some("my-project-456"));
+
+        let pending = json!({"done": false});
+        assert_eq!(yielded_project(&pending), None);
     }
 }

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -1,110 +1,158 @@
 //! Cloud Code Assist (CCA) transport logic for Antigravity integration.
 //!
-//! Handles request construction, signing, and response parsing for
-//! CCA-specific SSE endpoints.
+//! Handles onboarding a fresh Google OAuth token onto the Code Assist
+//! control plane (`cloudcode-pa.googleapis.com`) so subsequent chat calls
+//! resolve a Cloud project. The wire schema mirrors what Gemini CLI sends:
+//! camelCase fields, `cloudaicompanionProject` for the project handle, and a
+//! `metadata` object carrying `ideType` / `platform` / `pluginType`.
+//!
+//! The resolved project id is stored back on the token under
+//! `extra["project_id"]` (the same canonical key the LLM provider reads), so
+//! the auth step and the chat provider agree on the account's project.
 
-use crate::error::Result;
-use serde::{Deserialize, Serialize};
+use crate::error::{AuthError, Result};
+use crate::token::OAuthToken;
+use serde_json::{Value, json};
 
-/// Metadata sent by native Antigravity control-plane requests.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct AntigravityMetadata {
-    pub ide_type: String,
+const BASE: &str = "https://cloudcode-pa.googleapis.com/v1internal";
+
+/// Canonical `extra` key used to persist a resolved Google Cloud project id.
+pub const PROJECT_ID_KEY: &str = "project_id";
+
+/// Client metadata the Code Assist service expects (Gemini CLI sends the
+/// same shape; the values identify an Antigravity IDE).
+fn client_metadata() -> Value {
+    json!({
+        "ideType": "ANTIGRAVITY",
+        "platform": "PLATFORM_UNSPECIFIED",
+        "pluginType": "GEMINI",
+    })
 }
 
-impl Default for AntigravityMetadata {
-    fn default() -> Self {
-        Self {
-            ide_type: "ANTIGRAVITY".to_string(),
-        }
-    }
-}
-
-/// Base CCA request envelope.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CloudCodeRequest<T> {
-    #[serde(flatten)]
-    pub context: CloudCodeContext,
-    pub payload: T,
-}
-/// Perform a request to the Cloud Code Assist API.
-pub async fn request_cloud_code_assist<T, R>(
-    url: &str,
-    token: &str,
-    body: &CloudCodeRequest<T>,
-) -> Result<R>
-where
-    T: Serialize,
-    R: for<'de> Deserialize<'de>,
-{
-    let client = reqwest::Client::new();
-    let response = client
-        .post(url)
-        .header("Authorization", format!("Bearer {}", token))
+/// POST a JSON body to the Code Assist control plane and decode the JSON
+/// response. Non-success statuses surface the provider's `error.message`
+/// body rather than a bare "400 Bad Request".
+async fn post(suffix: &str, token: &str, body: &Value) -> Result<Value> {
+    let url = format!("{BASE}{suffix}");
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
         .json(body)
         .send()
         .await
-        .map_err(crate::error::AuthError::from)?
-        .error_for_status()
-        .map_err(crate::error::AuthError::from)?;
-
-    response
-        .json::<R>()
-        .await
-        .map_err(crate::error::AuthError::from)
+        .map_err(AuthError::from)?;
+    let status = resp.status();
+    let value: Value = resp.json().await.map_err(AuthError::from)?;
+    if !status.is_success() {
+        let msg = value["error"]["message"]
+            .as_str()
+            .unwrap_or("unknown error");
+        return Err(AuthError::Provider(format!(
+            "Code Assist request (`{suffix}`) failed ({status}): {msg}"
+        )));
+    }
+    Ok(value)
 }
-use crate::token::OAuthToken;
 
+/// Attach a Cloud project to `token` by discovering or creating one on the
+/// Code Assist control plane.
+///
+/// Resolution order matches `whycode-llm`'s Code Assist provider: an explicit
+/// `token.extra[PROJECT_ID_KEY]` (or `GOOGLE_CLOUD_PROJECT`) is used as-is;
+/// otherwise `loadCodeAssist` returns the managed project of an
+/// already-onboarded account, and a fallback runs `onboardUser` on the tier
+/// the account is allowed, polling the long-running operation until it
+/// yields a project id. On success the project id is stored on the token.
 pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAuthToken> {
-    let url = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
-    let request = CloudCodeRequest {
-        context: CloudCodeContext {
-            project_id: "whycodes".to_string(),
-            metadata: AntigravityMetadata::default(),
-        },
-        payload: serde_json::json!({}),
-    };
-
-    let response: LoadCodeAssistResponse =
-        request_cloud_code_assist(url, &token.access_token, &request).await?;
-
-    // Store project id if returned
-    if let Some(project_id) = extract_project_id(&response) {
+    if let Some(project) = explicit_project(&token) {
         token
             .extra
-            .insert("project_id".to_string(), serde_json::json!(project_id));
+            .insert(PROJECT_ID_KEY.to_string(), Value::String(project));
+        return Ok(token);
     }
 
-    Ok(token)
+    // 1. Already onboarded? loadCodeAssist reports the managed project (or
+    // the tiers the account may onboard into).
+    let load = post(
+        ":loadCodeAssist",
+        &token.access_token,
+        &json!({ "metadata": client_metadata() }),
+    )
+    .await?;
+    if let Some(id) = load["cloudaicompanionProject"].as_str() {
+        token
+            .extra
+            .insert(PROJECT_ID_KEY.to_string(), Value::String(id.to_string()));
+        return Ok(token);
+    }
+
+    // 2. Not onboarded: pick the free/managed tier and run onboardUser,
+    // polling the long-running operation until it yields a project id.
+    let tier = pick_tier(&load);
+    let onboard = post(
+        ":onboardUser",
+        &token.access_token,
+        &json!({ "tierId": tier, "metadata": client_metadata() }),
+    )
+    .await?;
+    let mut operation = onboard;
+    for _ in 0..10 {
+        if operation["done"].as_bool().unwrap_or(false) {
+            break;
+        }
+        let Some(name) = operation["name"].as_str().map(str::to_string) else {
+            break;
+        };
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        operation = post(&format!("/{name}"), &token.access_token, &json!({})).await?;
+    }
+
+    match operation["response"]["cloudaicompanionProject"]["id"].as_str() {
+        Some(id) => {
+            token
+                .extra
+                .insert(PROJECT_ID_KEY.to_string(), Value::String(id.to_string()));
+            Ok(token)
+        }
+        None => Err(AuthError::Provider(
+            "Code Assist onboarding did not yield a project id".into(),
+        )),
+    }
 }
 
-fn extract_project_id(response: &LoadCodeAssistResponse) -> Option<String> {
-    // According to oh-my-pi, project_id is often nested in the response structure
-    // We'll look for a plausible location or return None if it's missing
-    response
-        .allowed_tiers
-        .as_ref()?
-        .first()
-        .map(|t| t.id.clone())
+/// The tier to pass to `onboardUser`, from the `allowedTiers` the account
+/// reported in its `loadCodeAssist` response. Falls back to the free
+/// (managed-project) tier when the list is absent.
+fn pick_tier(load_response: &Value) -> String {
+    let find = |want_user_project: bool| {
+        load_response["allowedTiers"].as_array().and_then(|tiers| {
+            tiers
+                .iter()
+                .find(|t| {
+                    t["userDefinedCloudaicompanionProject"]
+                        .as_bool()
+                        .unwrap_or(false)
+                        == want_user_project
+                })
+                .and_then(|t| t["id"].as_str())
+                .map(str::to_string)
+        })
+    };
+    find(false).unwrap_or_else(|| "free-tier".to_string())
 }
 
-/// Context for Cloud Code requests.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct CloudCodeContext {
-    pub project_id: String,
-    pub metadata: AntigravityMetadata,
-}
-
-/// Cloud Code Assist response.
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct LoadCodeAssistResponse {
-    pub current_tier: Option<String>,
-    pub paid_tier: Option<String>,
-    pub allowed_tiers: Option<Vec<Tier>>,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct Tier {
-    pub id: String,
+/// A caller-supplied project: the stored token extra first, then the env.
+fn explicit_project(token: &OAuthToken) -> Option<String> {
+    token
+        .extra
+        .get(PROJECT_ID_KEY)
+        .and_then(Value::as_str)
+        .filter(|p| !p.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            std::env::var("GOOGLE_CLOUD_PROJECT")
+                .ok()
+                .filter(|p| !p.is_empty())
+        })
 }

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -77,12 +77,14 @@ async fn post(suffix: &str, token: &str, body: &Value) -> Result<Value> {
 /// Attach a Cloud project to `token` by discovering or creating one on the
 /// Code Assist control plane.
 ///
-/// Resolution order matches `whycode-llm`'s Code Assist provider: an explicit
-/// `token.extra[PROJECT_ID_KEY]` (or `GOOGLE_CLOUD_PROJECT`) is used as-is;
-/// otherwise `loadCodeAssist` returns the managed project of an
-/// already-onboarded account, and a fallback runs `onboardUser` on the tier
-/// the account is allowed, polling the long-running operation until it
-/// yields a project id. On success the project id is stored on the token.
+/// Resolution order mirrors the native Antigravity control-plane flow: an
+/// explicit `token.extra[PROJECT_ID_KEY]` (or `GOOGLE_CLOUD_PROJECT`) is used
+/// as-is; otherwise `loadCodeAssist` reports the project of an
+/// already-onboarded account — accounts with a bound tier skip provisioning
+/// entirely. Only fresh accounts run `onboardUser` (on the tier they are
+/// allowed), and the project is read back from a **fresh** `loadCodeAssist`,
+/// because the finished long-running operation frequently ships no project in
+/// its response body.
 pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAuthToken> {
     if let Some(project) = explicit_project(&token) {
         token
@@ -91,62 +93,127 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
         return Ok(token);
     }
 
-    // 1. Already onboarded? loadCodeAssist reports the managed project (or
-    // the tiers the account may onboard into).
-    let load = post(
-        ":loadCodeAssist",
-        &token.access_token,
-        &json!({ "metadata": client_metadata() }),
-    )
-    .await?;
-    if let Some(id) = load["cloudaicompanionProject"].as_str() {
-        token
-            .extra
-            .insert(PROJECT_ID_KEY.to_string(), Value::String(id.to_string()));
-        return Ok(token);
-    }
+    // 1. Account status (with the bind-and-confirm double call).
+    let load = load_code_assist(&token.access_token).await?;
 
-    // 2. Not onboarded: run onboardUser on the allowed tier and poll the
-    // long-running operation until it yields a project id. Provisioning can
-    // take a couple of minutes (project creation server-side), so poll well
-    // past a few seconds — bailing early surfaces as "no project id".
-    let tier = pick_tier(&load);
-    let mut body = json!({ "tierId": tier, "metadata": client_metadata() });
-    // Tiers flagged `userDefinedCloudaicompanionProject` (standard-tier for
-    // Pro accounts) expect the caller's own Cloud project in this field —
-    // same shape Gemini CLI sends. Harmless when absent.
-    if let Some(project) = explicit_project(&token) {
-        body["cloudaicompanionProject"] = Value::String(project);
-    }
-    let onboard = post(":onboardUser", &token.access_token, &body).await?;
-    let mut operation = onboard;
-    for _ in 0..60 {
-        if operation["done"].as_bool().unwrap_or(false) {
-            break;
+    // 2. Provisioning is only for accounts without a bound tier yet; calling
+    //    `onboardUser` on an already-onboarded (e.g. paid) account fails.
+    let mut operation: Option<Value> = None;
+    if load.get("currentTier").is_none_or(Value::is_null) {
+        surface_free_tier_ineligibility(&load)?;
+        let tier = pick_tier(&load);
+        let mut body = json!({ "tierId": tier, "metadata": client_metadata() });
+        // Tiers flagged `userDefinedCloudaicompanionProject` expect the
+        // caller's own Cloud project in this field — same shape Gemini CLI
+        // sends. Harmless when absent.
+        if let Some(project) = explicit_project(&token) {
+            body["cloudaicompanionProject"] = Value::String(project);
         }
-        let Some(name) = operation["name"].as_str().map(str::to_string) else {
-            break;
-        };
-        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-        operation = post(&format!("/{name}"), &token.access_token, &json!({})).await?;
+        let onboard = post(":onboardUser", &token.access_token, &body).await?;
+        let mut current = onboard;
+        for _ in 0..60 {
+            if current["done"].as_bool().unwrap_or(false) {
+                break;
+            }
+            let Some(name) = current["name"].as_str().map(str::to_string) else {
+                break;
+            };
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+            current = post(&format!("/{name}"), &token.access_token, &json!({})).await?;
+        }
+        if current["done"].as_bool().unwrap_or(false)
+            && let Some(err) = current["error"]["message"].as_str()
+        {
+            return Err(AuthError::Provider(format!(
+                "Code Assist onboarding operation failed: {err}"
+            )));
+        }
+        operation = Some(current);
     }
 
-    match yielded_project(&operation) {
+    // 3. Resolve the project: the authoritative fresh load first, then the
+    //    finished operation's body, and only then give up with guidance.
+    let refreshed = load_code_assist(&token.access_token).await?;
+    let resolved =
+        load_project(&refreshed).or_else(|| operation.as_ref().and_then(yielded_project));
+    match resolved {
         Some(id) => {
             token
                 .extra
                 .insert(PROJECT_ID_KEY.to_string(), Value::String(id));
             Ok(token)
         }
-        None => {
-            let done = operation["done"].as_bool().unwrap_or(false);
-            Err(AuthError::Provider(format!(
-                "Code Assist onboarding did not yield a project id \
-                 (operation done={done}, tier={tier}) — set GOOGLE_CLOUD_PROJECT \
-                 to your Cloud project id and retry"
-            )))
-        }
+        None => Err(AuthError::Provider(
+            "Code Assist onboarding did not yield a project id \
+             (loadCodeAssist returned no cloudaicompanionProject) — set \
+             GOOGLE_CLOUD_PROJECT to your Cloud project id and retry"
+                .into(),
+        )),
     }
+}
+
+/// POST `:loadCodeAssist`. When the first response reports a project without a
+/// paid-tier binding, repeat the call WITH that project handle (native
+/// Antigravity behavior) so the service binds it before reporting state.
+async fn load_code_assist(token: &str) -> Result<Value> {
+    let mut load = post(
+        ":loadCodeAssist",
+        token,
+        &json!({ "metadata": client_metadata() }),
+    )
+    .await?;
+    if let Some(project) = load_project(&load)
+        && load.get("paidTier").is_none_or(Value::is_null)
+    {
+        load = post(
+            ":loadCodeAssist",
+            token,
+            &json!({
+                "cloudaicompanionProject": project,
+                "metadata": client_metadata(),
+            }),
+        )
+        .await?;
+    }
+    Ok(load)
+}
+
+/// The plain-string project handle from a `loadCodeAssist` payload (the field
+/// ships as a bare string, not an object).
+fn load_project(payload: &Value) -> Option<String> {
+    payload["cloudaicompanionProject"]
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// Surface Google's own reason when the free tier is explicitly ineligible
+/// (`ineligibleTiers[].reasonMessage`) instead of tripping a raw 403 on
+/// `onboardUser` later.
+fn surface_free_tier_ineligibility(load: &Value) -> Result<()> {
+    let free_entry = || {
+        load["ineligibleTiers"].as_array().and_then(|tiers| {
+            tiers
+                .iter()
+                .find(|t| t["tierId"].as_str() == Some("free-tier"))
+        })
+    };
+    let eligible = load["allowedTiers"]
+        .as_array()
+        .is_some_and(|tiers| tiers.iter().any(|t| t["id"].as_str() == Some("free-tier")));
+    if eligible {
+        return Ok(());
+    }
+    if let Some(reason) = free_entry().and_then(|t| t["reasonMessage"].as_str()) {
+        let url = free_entry()
+            .and_then(|t| t["validationUrl"].as_str())
+            .map(|u| format!("\n{u}"))
+            .unwrap_or_default();
+        return Err(AuthError::Provider(format!(
+            "Google Code Assist: {reason}{url}"
+        )));
+    }
+    Ok(())
 }
 
 /// Pull the provisioned project id out of a finished `onboardUser` LRO.
@@ -245,5 +312,41 @@ mod tests {
 
         let pending = json!({"done": false});
         assert_eq!(yielded_project(&pending), None);
+    }
+
+    #[test]
+    fn load_project_reads_bare_string_field() {
+        let payload = json!({"cloudaicompanionProject": "proj-789"});
+        assert_eq!(load_project(&payload).as_deref(), Some("proj-789"));
+
+        let absent = json!({});
+        assert_eq!(load_project(&absent), None);
+
+        let empty = json!({"cloudaicompanionProject": ""});
+        assert_eq!(load_project(&empty), None);
+    }
+
+    #[test]
+    fn ineligibility_reason_is_surfaced() {
+        let ineligible = json!({
+            "allowedTiers": [{"id": "standard-tier"}],
+            "ineligibleTiers": [{
+                "tierId": "free-tier",
+                "reasonMessage": "not eligible for individuals",
+                "validationUrl": "https://example.com/fix"
+            }]
+        });
+        let err = surface_free_tier_ineligibility(&ineligible)
+            .expect_err("should surface Google's reason");
+        assert!(err.to_string().contains("not eligible for individuals"));
+        assert!(err.to_string().contains("https://example.com/fix"));
+
+        let eligible = json!({"allowedTiers": [
+            {"id": "free-tier"}, {"id": "standard-tier"}
+        ]});
+        assert!(surface_free_tier_ineligibility(&eligible).is_ok());
+
+        let silent = json!({});
+        assert!(surface_free_tier_ineligibility(&silent).is_ok());
     }
 }

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -141,8 +141,12 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
 }
 
 /// The tier to pass to `onboardUser`, from the `allowedTiers` the account
-/// reported in its `loadCodeAssist` response. Falls back to the free
-/// (managed-project) tier when the list is absent.
+/// reported in its `loadCodeAssist` response.
+///
+/// A Pro/paid account's tier list only carries `"standard-tier"` (which
+/// accepts a user-defined `cloudaicompanionProject`); forcing `"free-tier"`
+/// makes `onboardUser` reject the call with 403. Prefer the paid tier when
+/// present, and only fall back to the managed-project (free) tier otherwise.
 fn pick_tier(load_response: &Value) -> String {
     let find = |want_user_project: bool| {
         load_response["allowedTiers"].as_array().and_then(|tiers| {
@@ -158,7 +162,9 @@ fn pick_tier(load_response: &Value) -> String {
                 .map(str::to_string)
         })
     };
-    find(false).unwrap_or_else(|| "free-tier".to_string())
+    // Pro customers cannot onboard into the free tier; pick the one that
+    // takes a user-defined project when the account reports it.
+    find(true).unwrap_or_else(|| find(false).unwrap_or_else(|| "free-tier".to_string()))
 }
 
 /// A caller-supplied project: the stored token extra first, then the env.
@@ -174,4 +180,29 @@ fn explicit_project(token: &OAuthToken) -> Option<String> {
                 .ok()
                 .filter(|p| !p.is_empty())
         })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pick_tier_prefers_user_defined_project() {
+        let load = json!({"allowedTiers": [
+            {"id": "free-tier", "userDefinedCloudaicompanionProject": false},
+            {"id": "standard-tier", "userDefinedCloudaicompanionProject": true}
+        ]});
+        assert_eq!(pick_tier(&load), "standard-tier");
+    }
+
+    #[test]
+    fn pick_tier_falls_back_to_free_tier() {
+        let free = json!({"allowedTiers": [
+            {"id": "free-tier", "userDefinedCloudaicompanionProject": false}
+        ]});
+        assert_eq!(pick_tier(&free), "free-tier");
+
+        let empty = json!({});
+        assert_eq!(pick_tier(&empty), "free-tier");
+    }
 }

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -45,9 +45,28 @@ async fn post(suffix: &str, token: &str, body: &Value) -> Result<Value> {
     let status = resp.status();
     let value: Value = resp.json().await.map_err(AuthError::from)?;
     if !status.is_success() {
+        // The Code Assist control plane surfaces the actionable reason under
+        // `error.message`, but its "Your account is not eligible …" copy can
+        // be truncated (or replaced with a bare "unknown error") when the
+        // body shape differs. Favor `error.message`, then the message-only
+        // variant, and only then fall back to a keyword so the user still
+        // learns why sign-in was refused.
         let msg = value["error"]["message"]
             .as_str()
+            .or_else(|| value["message"].as_str())
+            .or_else(|| value["error"].as_str())
+            .filter(|s| !s.is_empty())
             .unwrap_or("unknown error");
+        // Detect the free-tier ineligibility reason even when the provider is
+        // terse, so the auth failure matches whycode-llm's actionable copy.
+        if status.as_u16() == 403
+            && (msg.to_ascii_lowercase().contains("eligib")
+                || msg.eq_ignore_ascii_case("unknown error"))
+        {
+            return Err(AuthError::Provider(format!(
+                "Code Assist request (`{suffix}`) failed ({status}): your Google account is not eligible for Gemini Code Assist for individuals (free tier) — use an AI Studio API key (GOOGLE_API_KEY) or a different account"
+            )));
+        }
         return Err(AuthError::Provider(format!(
             "Code Assist request (`{suffix}`) failed ({status}): {msg}"
         )));

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -60,7 +60,7 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
     let url = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
     let request = CloudCodeRequest {
         context: CloudCodeContext {
-            project_id: "projects/-".to_string(), // Try wildcard
+            project_id: "projects/whycodes".to_string(), // Try full project resource name
             metadata: AntigravityMetadata::default(),
         },
         payload: serde_json::json!({}), // Actual payload

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -57,7 +57,7 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
     let url = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
     let request = CloudCodeRequest {
         context: CloudCodeContext {
-            project_id: "projects/default".to_string(), // Placeholder, needs actual logic
+            project_id: "projects/-".to_string(), // Try wildcard
             metadata: AntigravityMetadata::default(),
         },
         payload: serde_json::json!({}), // Actual payload

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -1,10 +1,10 @@
 //! Cloud Code Assist (CCA) transport logic for Antigravity integration.
 //!
 //! Handles onboarding a fresh Google OAuth token onto the Code Assist
-//! control plane (`cloudcode-pa.googleapis.com`) so subsequent chat calls
-//! resolve a Cloud project. The wire schema mirrors what Gemini CLI sends:
+//! control plane (`daily-cloudcode-pa.googleapis.com`) so subsequent chat
+//! calls resolve a Cloud project. The wire schema mirrors native Antigravity:
 //! camelCase fields, `cloudaicompanionProject` for the project handle, and a
-//! `metadata` object carrying `ideType` / `platform` / `pluginType`.
+//! `metadata` object carrying `ideType: ANTIGRAVITY`.
 //!
 //! The resolved project id is stored back on the token under
 //! `extra["project_id"]` (the same canonical key the LLM provider reads), so
@@ -191,10 +191,22 @@ fn load_project(payload: &Value) -> Option<String> {
         .map(str::to_string)
 }
 
-/// Surface Google's own reason when the free tier is explicitly ineligible
-/// (`ineligibleTiers[].reasonMessage`) instead of tripping a raw 403 on
-/// `onboardUser` later.
+/// Surface Google's own reason when the account cannot onboard.
+///
+/// After Gemini Code Assist for individuals shut down (2026-06-18), Antigravity
+/// tokens often report `free-tier` as ineligible with "This client is no longer
+/// supported for Gemini Code Assist". That is expected and **not** fatal when
+/// another tier is in `allowedTiers` — `pick_tier` will onboard onto that one.
+/// Only fail when there is no allowed tier at all.
 fn surface_free_tier_ineligibility(load: &Value) -> Result<()> {
+    let has_allowed_tier = load["allowedTiers"].as_array().is_some_and(|tiers| {
+        tiers
+            .iter()
+            .any(|t| t["id"].as_str().is_some_and(|id| !id.is_empty()))
+    });
+    if has_allowed_tier {
+        return Ok(());
+    }
     let free_entry = || {
         load["ineligibleTiers"].as_array().and_then(|tiers| {
             tiers
@@ -202,12 +214,6 @@ fn surface_free_tier_ineligibility(load: &Value) -> Result<()> {
                 .find(|t| t["tierId"].as_str() == Some("free-tier"))
         })
     };
-    let eligible = load["allowedTiers"]
-        .as_array()
-        .is_some_and(|tiers| tiers.iter().any(|t| t["id"].as_str() == Some("free-tier")));
-    if eligible {
-        return Ok(());
-    }
     if let Some(reason) = free_entry().and_then(|t| t["reasonMessage"].as_str()) {
         let url = free_entry()
             .and_then(|t| t["validationUrl"].as_str())
@@ -332,8 +338,20 @@ mod tests {
 
     #[test]
     fn ineligibility_reason_is_surfaced() {
-        let ineligible = json!({
+        // A paid/Antigravity tier in allowedTiers means free-tier ineligibility
+        // is expected after the Gemini Code Assist consumer sunset — keep going.
+        let paid_allowed = json!({
             "allowedTiers": [{"id": "standard-tier"}],
+            "ineligibleTiers": [{
+                "tierId": "free-tier",
+                "reasonMessage": "This client is no longer supported for Gemini Code Assist",
+                "validationUrl": "https://example.com/fix"
+            }]
+        });
+        assert!(surface_free_tier_ineligibility(&paid_allowed).is_ok());
+
+        let ineligible = json!({
+            "allowedTiers": [],
             "ineligibleTiers": [{
                 "tierId": "free-tier",
                 "reasonMessage": "not eligible for individuals",

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -16,11 +16,12 @@ use serde_json::{Value, json};
 
 const BASE: &str = "https://daily-cloudcode-pa.googleapis.com/v1internal";
 
-/// User-Agent identifying as the native Antigravity client (captured from the
-/// real 2.8.0 `antigravity/hub` release). The backend gates the control plane
-/// on this header.
+/// User-Agent identifying as the native Antigravity client. Captured from the
+/// real 2.8.0 `antigravity/hub` release and pinned to that reference client's
+/// `os_type`/`arch` (darwin/arm64), independent of the host — the control plane
+/// gates on this header matching the reference, not the machine running whycode.
 const ANTIGRAVITY_USER_AGENT: &str =
-    "antigravity/hub/2.8.0 (aidev_client; os_type=linux; arch=x86_64; cl=963137146)";
+    "antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)";
 
 /// Canonical `extra` key used to persist a resolved Google Cloud project id.
 pub const PROJECT_ID_KEY: &str = "project_id";
@@ -36,16 +37,30 @@ fn client_metadata() -> Value {
 /// response. Non-success statuses surface the provider's `error.message`
 /// body rather than a bare "400 Bad Request".
 async fn post(suffix: &str, token: &str, body: &Value) -> Result<Value> {
+    send(reqwest::Method::POST, suffix, token, Some(body)).await
+}
+
+/// GET an LRO status. Native Antigravity / oh-my-pi poll `:onboardUser`
+/// operations with GET, not POST.
+async fn get(suffix: &str, token: &str) -> Result<Value> {
+    send(reqwest::Method::GET, suffix, token, None).await
+}
+
+async fn send(
+    method: reqwest::Method,
+    suffix: &str,
+    token: &str,
+    body: Option<&Value>,
+) -> Result<Value> {
     let url = format!("{BASE}{suffix}");
-    let resp = reqwest::Client::new()
-        .post(&url)
+    let mut req = reqwest::Client::new()
+        .request(method, &url)
         .header("Authorization", format!("Bearer {token}"))
-        .header("Content-Type", "application/json")
-        .header("User-Agent", ANTIGRAVITY_USER_AGENT)
-        .json(body)
-        .send()
-        .await
-        .map_err(AuthError::from)?;
+        .header("User-Agent", ANTIGRAVITY_USER_AGENT);
+    if let Some(body) = body {
+        req = req.header("Content-Type", "application/json").json(body);
+    }
+    let resp = req.send().await.map_err(AuthError::from)?;
     let status = resp.status();
     let value: Value = resp.json().await.map_err(AuthError::from)?;
     if !status.is_success() {
@@ -123,7 +138,7 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
                 break;
             };
             tokio::time::sleep(std::time::Duration::from_secs(3)).await;
-            current = post(&format!("/{name}"), &token.access_token, &json!({})).await?;
+            current = get(&format!("/{name}"), &token.access_token).await?;
         }
         if current["done"].as_bool().unwrap_or(false)
             && let Some(err) = current["error"]["message"].as_str()
@@ -282,6 +297,14 @@ fn explicit_project(token: &OAuthToken) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn user_agent_matches_native_reference_client() {
+        assert_eq!(
+            ANTIGRAVITY_USER_AGENT,
+            "antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)"
+        );
+    }
 
     #[test]
     fn pick_tier_prefers_user_defined_project() {

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -1,0 +1,100 @@
+//! Cloud Code Assist (CCA) transport logic for Antigravity integration.
+//!
+//! Handles request construction, signing, and response parsing for
+//! CCA-specific SSE endpoints.
+
+use serde::{Deserialize, Serialize};
+use crate::error::Result;
+
+/// Metadata sent by native Antigravity control-plane requests.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct AntigravityMetadata {
+    pub ide_type: String,
+}
+
+impl Default for AntigravityMetadata {
+    fn default() -> Self {
+        Self {
+            ide_type: "ANTIGRAVITY".to_string(),
+        }
+    }
+}
+
+/// Base CCA request envelope.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CloudCodeRequest<T> {
+    #[serde(flatten)]
+    pub context: CloudCodeContext,
+    pub payload: T,
+}
+/// Perform a request to the Cloud Code Assist API.
+pub async fn request_cloud_code_assist<T, R>(
+    url: &str,
+    token: &str,
+    body: &CloudCodeRequest<T>,
+) -> Result<R>
+where
+    T: Serialize,
+    R: for<'de> Deserialize<'de>,
+{
+    let client = reqwest::Client::new();
+    let response = client
+        .post(url)
+        .header("Authorization", format!("Bearer {}", token))
+        .header("Content-Type", "application/json")
+        .json(body)
+        .send()
+        .await
+        .map_err(crate::error::AuthError::from)?
+        .error_for_status()
+        .map_err(crate::error::AuthError::from)?;
+
+    response.json::<R>().await.map_err(crate::error::AuthError::from)
+}
+use crate::token::OAuthToken;
+
+pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAuthToken> {
+    let url = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
+    let request = CloudCodeRequest {
+        context: CloudCodeContext {
+            project_id: "projects/default".to_string(), // Placeholder, needs actual logic
+            metadata: AntigravityMetadata::default(),
+        },
+        payload: serde_json::json!({}), // Actual payload
+    };
+
+    let response: LoadCodeAssistResponse = request_cloud_code_assist(url, &token.access_token, &request).await?;
+    
+    // Store project id if returned
+    if let Some(project_id) = extract_project_id(&response) {
+        token.extra.insert("project_id".to_string(), serde_json::json!(project_id));
+    }
+    
+    Ok(token)
+}
+
+fn extract_project_id(response: &LoadCodeAssistResponse) -> Option<String> {
+    // According to oh-my-pi, project_id is often nested in the response structure
+    // We'll look for a plausible location or return None if it's missing
+    response.allowed_tiers.as_ref()?.first().map(|t| t.id.clone())
+}
+
+/// Context for Cloud Code requests.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct CloudCodeContext {
+    pub project_id: String,
+    pub metadata: AntigravityMetadata,
+}
+
+/// Cloud Code Assist response.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct LoadCodeAssistResponse {
+    pub current_tier: Option<String>,
+    pub paid_tier: Option<String>,
+    pub allowed_tiers: Option<Vec<Tier>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Tier {
+    pub id: String,
+}

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -3,8 +3,8 @@
 //! Handles request construction, signing, and response parsing for
 //! CCA-specific SSE endpoints.
 
-use serde::{Deserialize, Serialize};
 use crate::error::Result;
+use serde::{Deserialize, Serialize};
 
 /// Metadata sent by native Antigravity control-plane requests.
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -49,7 +49,10 @@ where
         .error_for_status()
         .map_err(crate::error::AuthError::from)?;
 
-    response.json::<R>().await.map_err(crate::error::AuthError::from)
+    response
+        .json::<R>()
+        .await
+        .map_err(crate::error::AuthError::from)
 }
 use crate::token::OAuthToken;
 
@@ -63,20 +66,27 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
         payload: serde_json::json!({}), // Actual payload
     };
 
-    let response: LoadCodeAssistResponse = request_cloud_code_assist(url, &token.access_token, &request).await?;
-    
+    let response: LoadCodeAssistResponse =
+        request_cloud_code_assist(url, &token.access_token, &request).await?;
+
     // Store project id if returned
     if let Some(project_id) = extract_project_id(&response) {
-        token.extra.insert("project_id".to_string(), serde_json::json!(project_id));
+        token
+            .extra
+            .insert("project_id".to_string(), serde_json::json!(project_id));
     }
-    
+
     Ok(token)
 }
 
 fn extract_project_id(response: &LoadCodeAssistResponse) -> Option<String> {
     // According to oh-my-pi, project_id is often nested in the response structure
     // We'll look for a plausible location or return None if it's missing
-    response.allowed_tiers.as_ref()?.first().map(|t| t.id.clone())
+    response
+        .allowed_tiers
+        .as_ref()?
+        .first()
+        .map(|t| t.id.clone())
 }
 
 /// Context for Cloud Code requests.

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -60,10 +60,10 @@ pub async fn perform_antigravity_onboarding(mut token: OAuthToken) -> Result<OAu
     let url = "https://cloudcode-pa.googleapis.com/v1internal:loadCodeAssist";
     let request = CloudCodeRequest {
         context: CloudCodeContext {
-            project_id: "projects/whycodes".to_string(), // Try full project resource name
+            project_id: "whycodes".to_string(),
             metadata: AntigravityMetadata::default(),
         },
-        payload: serde_json::json!({}), // Actual payload
+        payload: serde_json::json!({}),
     };
 
     let response: LoadCodeAssistResponse =

--- a/crates/auth/src/cca.rs
+++ b/crates/auth/src/cca.rs
@@ -14,19 +14,22 @@ use crate::error::{AuthError, Result};
 use crate::token::OAuthToken;
 use serde_json::{Value, json};
 
-const BASE: &str = "https://cloudcode-pa.googleapis.com/v1internal";
+const BASE: &str = "https://daily-cloudcode-pa.googleapis.com/v1internal";
+
+/// User-Agent identifying as the native Antigravity client (captured from the
+/// real 2.8.0 `antigravity/hub` release). The backend gates the control plane
+/// on this header.
+const ANTIGRAVITY_USER_AGENT: &str =
+    "antigravity/hub/2.8.0 (aidev_client; os_type=linux; arch=x86_64; cl=963137146)";
 
 /// Canonical `extra` key used to persist a resolved Google Cloud project id.
 pub const PROJECT_ID_KEY: &str = "project_id";
 
-/// Client metadata the Code Assist service expects (Gemini CLI sends the
-/// same shape; the values identify an Antigravity IDE).
+/// Client metadata the Code Assist service expects. The native Antigravity
+/// client sends only `ideType` — the extra `platform`/`pluginType` keys from
+/// the Gemini CLI provider are not part of this control plane's schema.
 fn client_metadata() -> Value {
-    json!({
-        "ideType": "ANTIGRAVITY",
-        "platform": "PLATFORM_UNSPECIFIED",
-        "pluginType": "GEMINI",
-    })
+    json!({ "ideType": "ANTIGRAVITY" })
 }
 
 /// POST a JSON body to the Code Assist control plane and decode the JSON
@@ -38,6 +41,7 @@ async fn post(suffix: &str, token: &str, body: &Value) -> Result<Value> {
         .post(&url)
         .header("Authorization", format!("Bearer {token}"))
         .header("Content-Type", "application/json")
+        .header("User-Agent", ANTIGRAVITY_USER_AGENT)
         .json(body)
         .send()
         .await

--- a/crates/auth/src/error.rs
+++ b/crates/auth/src/error.rs
@@ -5,7 +5,7 @@ pub enum AuthError {
     // NOTE: the supported list is tripwire-tested against OAUTH_PROVIDERS
     // (conformance_error_message_lists_every_provider) — keep it in sync.
     #[error(
-        "provider `{0}` does not support OAuth login (supported: anthropic, openai, github-copilot, google, xai)"
+        "provider `{0}` does not support OAuth login (supported: anthropic, openai, github-copilot, google, xai, google-antigravity)"
     )]
     UnsupportedProvider(String),
 

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -13,6 +13,7 @@
 //! - `Debug` impls redact token material.
 
 pub mod discover;
+pub mod cca;
 pub mod error;
 pub mod flow;
 pub mod pkce;
@@ -25,4 +26,4 @@ pub use store::TokenStore;
 pub use token::{OAuthToken, ProviderAuth};
 
 /// Providers that support OAuth subscription login.
-pub const OAUTH_PROVIDERS: &[&str] = &["anthropic", "openai", "github-copilot", "google", "xai"];
+pub const OAUTH_PROVIDERS: &[&str] = &["anthropic", "openai", "github-copilot", "google", "xai", "google-antigravity"];

--- a/crates/auth/src/lib.rs
+++ b/crates/auth/src/lib.rs
@@ -12,8 +12,8 @@
 //! - Secrets never appear in logs at any tracing level.
 //! - `Debug` impls redact token material.
 
-pub mod discover;
 pub mod cca;
+pub mod discover;
 pub mod error;
 pub mod flow;
 pub mod pkce;
@@ -26,4 +26,11 @@ pub use store::TokenStore;
 pub use token::{OAuthToken, ProviderAuth};
 
 /// Providers that support OAuth subscription login.
-pub const OAUTH_PROVIDERS: &[&str] = &["anthropic", "openai", "github-copilot", "google", "xai", "google-antigravity"];
+pub const OAUTH_PROVIDERS: &[&str] = &[
+    "anthropic",
+    "openai",
+    "github-copilot",
+    "google",
+    "xai",
+    "google-antigravity",
+];

--- a/crates/auth/src/providers.rs
+++ b/crates/auth/src/providers.rs
@@ -237,7 +237,11 @@ pub fn spec_for(provider: &str) -> Result<ProviderSpec> {
             client_secret: Some("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"),
             authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
             token_url: "https://oauth2.googleapis.com/token",
-            scopes: "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile",
+            // Native Antigravity also requests `cclog` + `experimentsandconfigs`.
+            // Without them `loadCodeAssist` classifies the session as Gemini
+            // Code Assist (sunset for consumer accounts on 2026-06-18) and
+            // returns "This client is no longer supported".
+            scopes: "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile https://www.googleapis.com/auth/cclog https://www.googleapis.com/auth/experimentsandconfigs",
             token_encoding: TokenEncoding::Form,
             redirect_uri: None,
             loopback_port: Some(51121),

--- a/crates/auth/src/providers.rs
+++ b/crates/auth/src/providers.rs
@@ -371,7 +371,6 @@ async fn login_with_spec<U: LoginUi>(
     })
 }
 
-
 /// Return a usable API credential for `provider` from the store under
 /// `data_dir`, refreshing it first when expired. `None` when not logged in
 /// or refresh fails (the caller then falls back to its normal error path).
@@ -484,7 +483,6 @@ fn usable_token(spec: &ProviderSpec, token: &OAuthToken) -> Option<String> {
     }
     Some(token.access_token.clone())
 }
-
 
 // ────────────────────────────────────────────────────────────────────────
 // Browser + localhost callback (OpenAI, Google)

--- a/crates/auth/src/providers.rs
+++ b/crates/auth/src/providers.rs
@@ -229,6 +229,23 @@ pub fn spec_for(provider: &str) -> Result<ProviderSpec> {
             extra_authorize: &[("referrer", "whycode")],
             derived: None,
         }),
+        "google-antigravity" => Ok(ProviderSpec {
+            name: "google-antigravity",
+            label: "Antigravity (Gemini 3, Claude, GPT-OSS)",
+            flow: FlowKind::LoopbackPkce,
+            client_id: "1071006060591-tmhssin2h21lcre235vtolojh4g403ep.apps.googleusercontent.com",
+            client_secret: Some("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"),
+            authorize_url: "https://accounts.google.com/o/oauth2/v2/auth",
+            token_url: "https://oauth2.googleapis.com/token",
+            scopes: "https://www.googleapis.com/auth/cloud-platform https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile",
+            token_encoding: TokenEncoding::Form,
+            redirect_uri: None,
+            loopback_port: Some(51121),
+            loopback_host: None,
+            callback_path: "/oauth-callback",
+            extra_authorize: &[("access_type", "offline"), ("prompt", "consent")],
+            derived: None,
+        }),
         other => Err(AuthError::UnsupportedProvider(other.to_string())),
     }
 }
@@ -337,18 +354,23 @@ async fn login_with_spec<U: LoginUi>(
     open_browser: bool,
     ui: &mut U,
 ) -> Result<ProviderAuth> {
-    let token = match spec.flow {
-        FlowKind::LoopbackPkce => loopback_login(spec, open_browser, ui).await?,
-        FlowKind::PasteCodePkce => paste_code_login(spec, open_browser, ui).await?,
-        FlowKind::DeviceCode => device_login(spec, open_browser, ui).await?,
+    let token = if spec.name == "google-antigravity" {
+        let oauth_token = loopback_login(spec, open_browser, ui).await?;
+        crate::cca::perform_antigravity_onboarding(oauth_token).await?
+    } else {
+        match spec.flow {
+            FlowKind::LoopbackPkce => loopback_login(spec, open_browser, ui).await?,
+            FlowKind::PasteCodePkce => paste_code_login(spec, open_browser, ui).await?,
+            FlowKind::DeviceCode => device_login(spec, open_browser, ui).await?,
+        }
     };
-    let auth = ProviderAuth {
+    persist_token(store, spec.name, "oauth", &token)?;
+    Ok(ProviderAuth {
         method: "oauth".to_string(),
         token,
-    };
-    store.set(spec.name, auth.clone())?;
-    Ok(auth)
+    })
 }
+
 
 /// Return a usable API credential for `provider` from the store under
 /// `data_dir`, refreshing it first when expired. `None` when not logged in
@@ -453,7 +475,6 @@ async fn ensure_fresh(
 fn usable_token(spec: &ProviderSpec, token: &OAuthToken) -> Option<String> {
     if spec.derived.is_some() {
         // "copilot_token" is the pre-rename key; read it so stores written
-        // by older builds keep working.
         return token
             .extra
             .get("derived_token")
@@ -463,6 +484,7 @@ fn usable_token(spec: &ProviderSpec, token: &OAuthToken) -> Option<String> {
     }
     Some(token.access_token.clone())
 }
+
 
 // ────────────────────────────────────────────────────────────────────────
 // Browser + localhost callback (OpenAI, Google)
@@ -957,6 +979,7 @@ pub fn suggested_models(provider: &str) -> &'static [&'static str] {
         "github-copilot" => &["gpt-4.1", "gpt-4o"],
         "google" => &["gemini-3.6-flash", "gemini-3.5-flash"],
         "xai" => &["grok-4.6", "grok-4.5", "grok-build-0.1"],
+        "google-antigravity" => &["gemini-3.1-pro", "gemini-3.1-flash", "claude-sonnet-4-6"],
         _ => &[],
     }
 }

--- a/crates/auth/src/providers.rs
+++ b/crates/auth/src/providers.rs
@@ -245,7 +245,7 @@ pub fn spec_for(provider: &str) -> Result<ProviderSpec> {
             token_encoding: TokenEncoding::Form,
             redirect_uri: None,
             loopback_port: Some(51121),
-            loopback_host: None,
+            loopback_host: Some("127.0.0.1"),
             callback_path: "/oauth-callback",
             extra_authorize: &[("access_type", "offline"), ("prompt", "consent")],
             derived: None,

--- a/crates/auth/src/providers.rs
+++ b/crates/auth/src/providers.rs
@@ -981,7 +981,11 @@ pub fn suggested_models(provider: &str) -> &'static [&'static str] {
         "github-copilot" => &["gpt-4.1", "gpt-4o"],
         "google" => &["gemini-3.6-flash", "gemini-3.5-flash"],
         "xai" => &["grok-4.6", "grok-4.5", "grok-build-0.1"],
-        "google-antigravity" => &["gemini-3.1-pro", "gemini-3.1-flash", "claude-sonnet-4-6"],
+        "google-antigravity" => &[
+            "gemini-3.1-pro-low",
+            "gemini-3.5-flash-low",
+            "claude-sonnet-4-6",
+        ],
         _ => &[],
     }
 }

--- a/crates/auth/src/providers_tests.rs
+++ b/crates/auth/src/providers_tests.rs
@@ -165,6 +165,7 @@ fn antigravity_requests_native_client_scopes() {
     let spec = spec_for("google-antigravity").unwrap();
     assert_eq!(spec.flow, FlowKind::LoopbackPkce);
     assert_eq!(spec.loopback_port, Some(51121));
+    assert_eq!(spec.loopback_host, Some("127.0.0.1"));
     assert_eq!(spec.callback_path, "/oauth-callback");
     for scope in [
         "https://www.googleapis.com/auth/cloud-platform",

--- a/crates/auth/src/providers_tests.rs
+++ b/crates/auth/src/providers_tests.rs
@@ -161,6 +161,26 @@ fn flow_kinds_match_registered_redirects() {
 }
 
 #[test]
+fn antigravity_requests_native_client_scopes() {
+    let spec = spec_for("google-antigravity").unwrap();
+    assert_eq!(spec.flow, FlowKind::LoopbackPkce);
+    assert_eq!(spec.loopback_port, Some(51121));
+    assert_eq!(spec.callback_path, "/oauth-callback");
+    for scope in [
+        "https://www.googleapis.com/auth/cloud-platform",
+        "https://www.googleapis.com/auth/userinfo.email",
+        "https://www.googleapis.com/auth/userinfo.profile",
+        "https://www.googleapis.com/auth/cclog",
+        "https://www.googleapis.com/auth/experimentsandconfigs",
+    ] {
+        assert!(
+            spec.scopes.split_whitespace().any(|s| s == scope),
+            "google-antigravity missing native scope {scope}"
+        );
+    }
+}
+
+#[test]
 fn token_from_json_accepts_string_or_number_expires_in() {
     let t = token_from_json(&serde_json::json!({
         "access_token": "a", "refresh_token": "r", "expires_in": 3600

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -327,7 +327,7 @@ pub enum ProviderCmd {
 pub enum AuthCmd {
     /// Log in with a provider subscription (opens a browser)
     Login {
-        /// Provider: anthropic | openai | github-copilot | google | xai
+        /// Provider: anthropic | openai | github-copilot | google | google-antigravity | xai
         provider: String,
         /// Print the sign-in URL instead of opening a browser
         #[arg(long)]
@@ -335,7 +335,7 @@ pub enum AuthCmd {
     },
     /// Remove stored OAuth credentials for a provider
     Logout {
-        /// Provider: anthropic | openai | github-copilot | google | xai
+        /// Provider: anthropic | openai | github-copilot | google | google-antigravity | xai
         provider: String,
     },
     /// Show which providers have stored OAuth credentials (never prints tokens)

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1043,6 +1043,7 @@ fn default_prompt_suggestions() -> String {
 pub struct GeneralConfig {
     pub project_path: Option<PathBuf>,
     pub log_level: Option<String>,
+    pub default_gcp_project: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/core/src/tests.rs
+++ b/crates/core/src/tests.rs
@@ -1797,6 +1797,7 @@ mod types_tests {
             "groq",
             "deepseek",
             "google",
+            "google-antigravity",
             "gemini",
             "azure",
             "openrouter",

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -402,6 +402,7 @@ impl ProviderConfig {
             "groq" => "https://api.groq.com/openai/v1",
             "deepseek" => "https://api.deepseek.com/v1",
             "google" | "gemini" => "https://generativelanguage.googleapis.com/v1beta",
+            "google-antigravity" => "https://daily-cloudcode-pa.googleapis.com/v1internal",
             "azure" | "azure_openai" => "https://{resource}.openai.azure.com/openai",
             "openrouter" => "https://openrouter.ai/api/v1",
             "together" | "together_ai" => "https://api.together.xyz/v1",

--- a/crates/llm/src/capabilities.rs
+++ b/crates/llm/src/capabilities.rs
@@ -87,6 +87,7 @@ pub fn detect_capabilities(provider: &str, model: &str) -> ModelCapabilities {
         "openai"
             | "anthropic"
             | "google"
+            | "google-antigravity"
             | "gemini"
             | "deepseek"
             | "openrouter"
@@ -599,6 +600,7 @@ mod tests {
         let cases = [
             ("gateway", "custom-gpt-4-32k-endpoint", 32_000),
             ("google", "gemini-flash-experimental", 128_000),
+            ("google-antigravity", "gemini-3.1-pro", 128_000),
             ("anthropic", "claude-future", 200_000),
             ("deepseek", "deepseek-coder-v2", 64_000),
             ("mistral", "mistral-medium-latest", 32_000),

--- a/crates/llm/src/error_class.rs
+++ b/crates/llm/src/error_class.rs
@@ -105,6 +105,13 @@ impl ClassifiedError {
             }
             ErrorKind::Client => {
                 if let Some(s) = self.status {
+                    // Surface model/host from Code Assist 404s so "unknown
+                    // family id" is distinguishable from a dead endpoint.
+                    let m = self.message.trim();
+                    if let Some(idx) = m.find("model=") {
+                        let rest: String = m[idx..].chars().take(80).collect();
+                        return format!("Request rejected (HTTP {s}): {rest}");
+                    }
                     format!("Request rejected (HTTP {s})")
                 } else {
                     "Request rejected by the provider".into()
@@ -563,6 +570,17 @@ mod tests {
         assert_eq!(c.kind, ErrorKind::Client);
         assert!(!c.retryable);
         assert_eq!(c.user_message(), "Request rejected (HTTP 422)");
+    }
+
+    #[test]
+    fn code_assist_404_surfaces_the_model() {
+        let c =
+            classify_message("LLM error: Code Assist error (404) model=gemini-3.1-pro: Not Found");
+        assert_eq!(c.kind, ErrorKind::Client);
+        assert_eq!(c.status, Some(404));
+        let msg = c.user_message();
+        assert!(msg.contains("404"), "{msg}");
+        assert!(msg.contains("model=gemini-3.1-pro"), "{msg}");
     }
 
     #[test]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -20,8 +20,8 @@ pub mod types;
 pub mod usage_dump;
 
 pub use providers::{
-    anthropic, codeassist, codex, copilot, custom, deepseek, google, groq, mistral, ollama, openai,
-    openrouter, together, xai,
+    anthropic, antigravity, codeassist, codex, copilot, custom, deepseek, google, groq, mistral,
+    ollama, openai, openrouter, together, xai,
 };
 
 pub use cache::{CacheConfig, CachePolicy, apply_anthropic_cache_policy};

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -86,6 +86,9 @@ impl Default for ProviderRegistry {
         registry.register(Box::new(super::providers::openai::OpenAiProvider::new()));
         registry.register(Box::new(super::providers::copilot::CopilotProvider::new()));
         registry.register(Box::new(super::providers::google::GoogleProvider::new()));
+        registry.register(Box::new(
+            super::providers::antigravity::AntigravityProvider::new(),
+        ));
         registry.register(Box::new(super::providers::deepseek::DeepSeekProvider::new()));
         registry.register(Box::new(
             super::providers::openrouter::OpenRouterProvider::new(),
@@ -126,6 +129,7 @@ mod tests {
             "openai",
             "github-copilot",
             "google",
+            "google-antigravity",
             "deepseek",
             "openrouter",
             "ollama",

--- a/crates/llm/src/providers/antigravity.rs
+++ b/crates/llm/src/providers/antigravity.rs
@@ -1,0 +1,75 @@
+//! Google Antigravity subscription LLM provider.
+//!
+//! Always routes through the Antigravity Code Assist control plane
+//! (`daily-cloudcode-pa.googleapis.com`). OAuth tokens come from
+//! `whycode auth login google-antigravity`.
+
+use super::codeassist;
+use crate::provider::LlmProvider;
+use async_trait::async_trait;
+use futures::stream::Stream;
+use std::pin::Pin;
+use whycode_core::types::{LlmRequest, LlmResponse, StreamEvent};
+
+pub struct AntigravityProvider {
+    name: String,
+}
+
+impl AntigravityProvider {
+    pub fn new() -> Self {
+        Self {
+            name: "google-antigravity".to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AntigravityProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn default_base_url(&self) -> &str {
+        "https://daily-cloudcode-pa.googleapis.com/v1internal"
+    }
+
+    async fn complete(
+        &self,
+        request: &LlmRequest,
+        api_key: &str,
+        model: &str,
+    ) -> whycode_core::Result<LlmResponse> {
+        codeassist::complete_antigravity(request, api_key, model).await
+    }
+
+    async fn stream(
+        &self,
+        request: &LlmRequest,
+        api_key: &str,
+        model: &str,
+    ) -> whycode_core::Result<Pin<Box<dyn Stream<Item = whycode_core::Result<StreamEvent>> + Send>>>
+    {
+        codeassist::stream_antigravity(request, api_key, model).await
+    }
+}
+
+impl Default for AntigravityProvider {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity() {
+        let p = AntigravityProvider::new();
+        assert_eq!(p.name(), "google-antigravity");
+        assert_eq!(
+            p.default_base_url(),
+            "https://daily-cloudcode-pa.googleapis.com/v1internal"
+        );
+    }
+}

--- a/crates/llm/src/providers/codeassist.rs
+++ b/crates/llm/src/providers/codeassist.rs
@@ -7,21 +7,52 @@
 //! envelope. `GoogleProvider` delegates here when the credential is an
 //! OAuth access token (`ya29.…`); `AIza…` API keys keep the old path.
 //!
+//! Antigravity subscription tokens (`whycode auth login google-antigravity`)
+//! use the same RPC shape against `daily-cloudcode-pa.googleapis.com` with
+//! the native hub User-Agent and `{ ideType: ANTIGRAVITY }` metadata.
+//!
 //! Code Assist needs a Cloud project id. Resolution order:
-//! `GOOGLE_CLOUD_PROJECT` env → `loadCodeAssist` (an already-onboarded
-//! account returns its managed project) → `onboardUser` on the free tier
-//! (long-running operation, polled). The result is cached process-wide.
+//! stored OAuth extra `project_id` → `GOOGLE_CLOUD_PROJECT` env →
+//! `loadCodeAssist` (an already-onboarded account returns its managed
+//! project) → `onboardUser` on the free tier (long-running operation,
+//! polled). The result is cached process-wide per OAuth provider.
 
 use async_stream::stream;
 use futures::stream::{Stream, StreamExt};
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::{OnceLock, RwLock};
 use whycode_core::types::{
     ContentBlock, LlmRequest, LlmResponse, MessageContent, Role, StreamEvent, Usage,
 };
 
-const BASE: &str = "https://cloudcode-pa.googleapis.com/v1internal";
+const GEMINI_CLI_BASE: &str = "https://cloudcode-pa.googleapis.com/v1internal";
+const ANTIGRAVITY_BASE: &str = "https://daily-cloudcode-pa.googleapis.com/v1internal";
+const ANTIGRAVITY_USER_AGENT: &str =
+    "antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)";
+
+#[derive(Clone, Copy)]
+struct Profile {
+    oauth_provider: &'static str,
+    base: &'static str,
+    user_agent: Option<&'static str>,
+    antigravity: bool,
+}
+
+const GEMINI_CLI: Profile = Profile {
+    oauth_provider: "google",
+    base: GEMINI_CLI_BASE,
+    user_agent: None,
+    antigravity: false,
+};
+
+const ANTIGRAVITY: Profile = Profile {
+    oauth_provider: "google-antigravity",
+    base: ANTIGRAVITY_BASE,
+    user_agent: Some(ANTIGRAVITY_USER_AGENT),
+    antigravity: true,
+};
 
 /// Client metadata the Code Assist service expects (Gemini CLI sends the
 /// same shape; the values label an unspecified IDE on the current platform).
@@ -33,67 +64,120 @@ fn client_metadata() -> Value {
     })
 }
 
+fn metadata_for(profile: &Profile) -> Value {
+    if profile.antigravity {
+        json!({ "ideType": "ANTIGRAVITY" })
+    } else {
+        client_metadata()
+    }
+}
+
 /// True when `key` is a Google OAuth access token rather than an API key
 /// (`AIza…`). OAuth tokens are rejected by the generativelanguage route.
 pub fn is_google_oauth_token(key: &str) -> bool {
     key.starts_with("ya29.")
 }
 
-/// Process-wide cache for the resolved Code Assist project id.
-fn project_cache() -> &'static RwLock<Option<String>> {
-    static CACHE: OnceLock<RwLock<Option<String>>> = OnceLock::new();
-    CACHE.get_or_init(|| RwLock::new(None))
+/// Process-wide cache for the resolved Code Assist project id, keyed by
+/// OAuth provider (`google` vs `google-antigravity`).
+fn project_cache() -> &'static RwLock<HashMap<String, String>> {
+    static CACHE: OnceLock<RwLock<HashMap<String, String>>> = OnceLock::new();
+    CACHE.get_or_init(|| RwLock::new(HashMap::new()))
 }
 
-fn cached_project() -> Option<String> {
-    project_cache().read().ok()?.clone()
+fn cached_project(provider: &str) -> Option<String> {
+    project_cache().read().ok()?.get(provider).cloned()
 }
 
-fn cache_project(id: &str) {
+fn cache_project(provider: &str, id: &str) {
     if let Ok(mut guard) = project_cache().write() {
-        *guard = Some(id.to_string());
+        guard.insert(provider.to_string(), id.to_string());
     }
 }
 
-/// POST `{BASE}{path}` with the OAuth bearer token; a 401 force-renews the
-/// stored credential once via `oauth_refresh` (Google tokens last 1h, so a
+fn authorize(
+    profile: &Profile,
+    req: reqwest::RequestBuilder,
+    key: &str,
+) -> reqwest::RequestBuilder {
+    let req = req.header("Authorization", format!("Bearer {key}"));
+    if let Some(ua) = profile.user_agent {
+        req.header("User-Agent", ua)
+    } else {
+        crate::client_identity::with_identity(req)
+    }
+}
+
+/// POST `{profile.base}{path}` with the OAuth bearer token; a 401 force-renews
+/// the stored credential once via `oauth_refresh` (Google tokens last 1h, so a
 /// revoked or early-expired token is the common failure).
-async fn post(path: &str, api_key: &str, body: &Value) -> whycode_core::Result<reqwest::Response> {
-    crate::oauth_refresh::send_with_refresh_retry("google", api_key, |key| {
-        crate::client_identity::post(format!("{BASE}{path}").as_str())
-            .header("Authorization", format!("Bearer {key}"))
-            .json(body)
+async fn post(
+    profile: &Profile,
+    path: &str,
+    api_key: &str,
+    body: &Value,
+) -> whycode_core::Result<reqwest::Response> {
+    let url = format!("{}{path}", profile.base);
+    crate::oauth_refresh::send_with_refresh_retry(profile.oauth_provider, api_key, |key| {
+        authorize(
+            profile,
+            crate::client_identity::http_client().post(&url),
+            key,
+        )
+        .header("Content-Type", "application/json")
+        .json(body)
     })
     .await
 }
 
-/// GET an LRO status (`GET {BASE}/{operation_name}`) with the same retry.
-async fn get(path: &str, api_key: &str) -> whycode_core::Result<reqwest::Response> {
-    crate::oauth_refresh::send_with_refresh_retry("google", api_key, |key| {
-        crate::client_identity::http_client()
-            .get(format!("{BASE}{path}").as_str())
-            .header("Authorization", format!("Bearer {key}"))
+/// GET an LRO status (`GET {profile.base}/{operation_name}`) with the same retry.
+async fn get(
+    profile: &Profile,
+    path: &str,
+    api_key: &str,
+) -> whycode_core::Result<reqwest::Response> {
+    let url = format!("{}{path}", profile.base);
+    crate::oauth_refresh::send_with_refresh_retry(profile.oauth_provider, api_key, |key| {
+        authorize(
+            profile,
+            crate::client_identity::http_client().get(&url),
+            key,
+        )
     })
     .await
 }
 
 /// Resolve the Code Assist project id for this credential, cached
-/// process-wide. See the module docs for the resolution order.
-async fn project_id(api_key: &str) -> whycode_core::Result<String> {
-    if let Some(cached) = cached_project() {
+/// process-wide per OAuth provider. See the module docs for the resolution
+/// order.
+async fn project_id(profile: &Profile, api_key: &str) -> whycode_core::Result<String> {
+    if let Some(cached) = cached_project(profile.oauth_provider) {
         return Ok(cached);
+    }
+    if let Some(id) = crate::oauth_refresh::stored_extra(profile.oauth_provider, "project_id")
+        .await
+        .filter(|p| !p.is_empty())
+    {
+        cache_project(profile.oauth_provider, &id);
+        return Ok(id);
     }
     let env_project = std::env::var("GOOGLE_CLOUD_PROJECT")
         .ok()
         .filter(|p| !p.is_empty())
-        .or(Some("whycodes".to_string()));
+        .or_else(|| {
+            if profile.antigravity {
+                None
+            } else {
+                Some("whycodes".to_string())
+            }
+        });
 
     // 1. loadCodeAssist: an already-onboarded account reports its project.
-    let mut load_body = json!({ "metadata": client_metadata() });
+    let mut load_body = json!({ "metadata": metadata_for(profile) });
     if let Some(p) = &env_project {
         load_body["cloudaicompanionProject"] = Value::String(p.clone());
     }
-    let resp = post(":loadCodeAssist", api_key, &load_body).await?;
+    let resp = post(profile, ":loadCodeAssist", api_key, &load_body).await?;
     let status = resp.status();
     let json: Value = resp
         .json()
@@ -106,25 +190,25 @@ async fn project_id(api_key: &str) -> whycode_core::Result<String> {
         )));
     }
     if let Some(id) = json["cloudaicompanionProject"].as_str() {
-        cache_project(id);
+        cache_project(profile.oauth_provider, id);
         return Ok(id.to_string());
     }
     if json["currentTier"].is_object()
         && let Some(p) = &env_project
     {
         // Paid tier without a reported project: the env project is the one.
-        cache_project(p);
+        cache_project(profile.oauth_provider, p);
         return Ok(p.clone());
     }
 
     // 2. Not onboarded: pick a tier (free tier unless the user brought a
     // project) and run onboardUser, polling the long-running operation.
     let tier = pick_tier(&json, env_project.is_some());
-    let mut onboard = json!({ "tierId": tier, "metadata": client_metadata() });
+    let mut onboard = json!({ "tierId": tier, "metadata": metadata_for(profile) });
     if let Some(p) = &env_project {
         onboard["cloudaicompanionProject"] = Value::String(p.clone());
     }
-    let resp = post(":onboardUser", api_key, &onboard).await?;
+    let resp = post(profile, ":onboardUser", api_key, &onboard).await?;
     let status = resp.status();
     let op: Value = resp
         .json()
@@ -146,7 +230,7 @@ async fn project_id(api_key: &str) -> whycode_core::Result<String> {
             break;
         };
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-        let resp = get(&format!("/{name}"), api_key).await?;
+        let resp = get(profile, &format!("/{name}"), api_key).await?;
         operation = resp
             .json()
             .await
@@ -162,7 +246,7 @@ async fn project_id(api_key: &str) -> whycode_core::Result<String> {
                     .to_string(),
             )
         })?;
-    cache_project(project);
+    cache_project(profile.oauth_provider, project);
     Ok(project.to_string())
 }
 
@@ -280,6 +364,42 @@ fn build_inner_request(request: &LlmRequest) -> Value {
     inner
 }
 
+fn apply_antigravity_inner(inner: &mut Value, request: &LlmRequest) {
+    if let Some(si) = inner.get_mut("systemInstruction") {
+        si["role"] = json!("user");
+    }
+    if !request.tools.is_empty() {
+        inner["toolConfig"] = json!({
+            "functionCallingConfig": { "mode": "VALIDATED" }
+        });
+    }
+}
+
+fn wrap_envelope(
+    profile: &Profile,
+    model: &str,
+    project: &str,
+    mut inner: Value,
+    request: &LlmRequest,
+) -> Value {
+    if profile.antigravity {
+        apply_antigravity_inner(&mut inner, request);
+        json!({
+            "model": model,
+            "project": project,
+            "request": inner,
+            "userAgent": "antigravity",
+            "requestType": "agent",
+        })
+    } else {
+        json!({
+            "model": model,
+            "project": project,
+            "request": inner,
+        })
+    }
+}
+
 /// Map one Code Assist SSE chunk (a GenerateContentResponse, tolerating a
 /// `{"response": …}` wrapper) to whycode stream events. Pure for tests.
 /// `call_seq` mints ids for function calls — Gemini does not send any, but
@@ -335,13 +455,33 @@ pub async fn complete(
     api_key: &str,
     model: &str,
 ) -> whycode_core::Result<LlmResponse> {
-    let project = project_id(api_key).await?;
-    let body = json!({
-        "model": model,
-        "project": project,
-        "request": build_inner_request(request),
-    });
-    let resp = post(":generateContent", api_key, &body).await?;
+    complete_with(&GEMINI_CLI, request, api_key, model).await
+}
+
+/// Antigravity subscription path (`google-antigravity` OAuth).
+pub async fn complete_antigravity(
+    request: &LlmRequest,
+    api_key: &str,
+    model: &str,
+) -> whycode_core::Result<LlmResponse> {
+    complete_with(&ANTIGRAVITY, request, api_key, model).await
+}
+
+async fn complete_with(
+    profile: &Profile,
+    request: &LlmRequest,
+    api_key: &str,
+    model: &str,
+) -> whycode_core::Result<LlmResponse> {
+    let project = project_id(profile, api_key).await?;
+    let body = wrap_envelope(
+        profile,
+        model,
+        &project,
+        build_inner_request(request),
+        request,
+    );
+    let resp = post(profile, ":generateContent", api_key, &body).await?;
     let status = resp.status();
     let json: Value = resp
         .json()
@@ -403,13 +543,33 @@ pub async fn stream(
     api_key: &str,
     model: &str,
 ) -> whycode_core::Result<Pin<Box<dyn Stream<Item = whycode_core::Result<StreamEvent>> + Send>>> {
-    let project = project_id(api_key).await?;
-    let body = json!({
-        "model": model,
-        "project": project,
-        "request": build_inner_request(request),
-    });
-    let resp = post(":streamGenerateContent?alt=sse", api_key, &body).await?;
+    stream_with(&GEMINI_CLI, request, api_key, model).await
+}
+
+/// Antigravity subscription path (`google-antigravity` OAuth).
+pub async fn stream_antigravity(
+    request: &LlmRequest,
+    api_key: &str,
+    model: &str,
+) -> whycode_core::Result<Pin<Box<dyn Stream<Item = whycode_core::Result<StreamEvent>> + Send>>> {
+    stream_with(&ANTIGRAVITY, request, api_key, model).await
+}
+
+async fn stream_with(
+    profile: &Profile,
+    request: &LlmRequest,
+    api_key: &str,
+    model: &str,
+) -> whycode_core::Result<Pin<Box<dyn Stream<Item = whycode_core::Result<StreamEvent>> + Send>>> {
+    let project = project_id(profile, api_key).await?;
+    let body = wrap_envelope(
+        profile,
+        model,
+        &project,
+        build_inner_request(request),
+        request,
+    );
+    let resp = post(profile, ":streamGenerateContent?alt=sse", api_key, &body).await?;
 
     if !resp.status().is_success() {
         let status = resp.status();
@@ -497,6 +657,41 @@ mod tests {
                 "pluginType": "GEMINI",
             })
         );
+        assert_eq!(
+            metadata_for(&ANTIGRAVITY),
+            json!({ "ideType": "ANTIGRAVITY" })
+        );
+    }
+
+    #[test]
+    fn antigravity_envelope_tags_native_client() {
+        let request = empty_request(vec![message(
+            Role::User,
+            MessageContent::Text("hi".to_string()),
+        )]);
+        let mut inner = build_inner_request(&history_with_tool_call());
+        apply_antigravity_inner(&mut inner, &history_with_tool_call());
+        assert_eq!(inner["systemInstruction"]["role"], "user");
+        assert_eq!(
+            inner["toolConfig"]["functionCallingConfig"]["mode"],
+            "VALIDATED"
+        );
+
+        let body = wrap_envelope(&ANTIGRAVITY, "gemini-3.1-pro", "proj", inner, &request);
+        assert_eq!(body["userAgent"], "antigravity");
+        assert_eq!(body["requestType"], "agent");
+        assert_eq!(body["project"], "proj");
+        assert_eq!(body["model"], "gemini-3.1-pro");
+
+        let gemini = wrap_envelope(
+            &GEMINI_CLI,
+            "gemini-2.5-pro",
+            "g",
+            build_inner_request(&request),
+            &request,
+        );
+        assert!(gemini.get("userAgent").is_none());
+        assert!(gemini.get("requestType").is_none());
     }
 
     #[test]

--- a/crates/llm/src/providers/codeassist.rs
+++ b/crates/llm/src/providers/codeassist.rs
@@ -85,7 +85,8 @@ async fn project_id(api_key: &str) -> whycode_core::Result<String> {
     }
     let env_project = std::env::var("GOOGLE_CLOUD_PROJECT")
         .ok()
-        .filter(|p| !p.is_empty());
+        .filter(|p| !p.is_empty())
+        .or(Some("whycodes".to_string()));
 
     // 1. loadCodeAssist: an already-onboarded account reports its project.
     let mut load_body = json!({ "metadata": client_metadata() });

--- a/crates/llm/src/providers/codeassist.rs
+++ b/crates/llm/src/providers/codeassist.rs
@@ -27,32 +27,48 @@ use whycode_core::types::{
     ContentBlock, LlmRequest, LlmResponse, MessageContent, Role, StreamEvent, Usage,
 };
 
-const GEMINI_CLI_BASE: &str = "https://cloudcode-pa.googleapis.com/v1internal";
-const ANTIGRAVITY_BASE: &str = "https://daily-cloudcode-pa.googleapis.com/v1internal";
+const GEMINI_CLI_BASES: &[&str] = &["https://cloudcode-pa.googleapis.com/v1internal"];
+const ANTIGRAVITY_BASES: &[&str] = &[
+    "https://daily-cloudcode-pa.googleapis.com/v1internal",
+    "https://daily-cloudcode-pa.sandbox.googleapis.com/v1internal",
+];
 const ANTIGRAVITY_USER_AGENT: &str =
     "antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64; cl=963137146)";
 
 #[derive(Clone, Copy)]
 struct Profile {
     oauth_provider: &'static str,
-    base: &'static str,
+    bases: &'static [&'static str],
     user_agent: Option<&'static str>,
     antigravity: bool,
 }
 
 const GEMINI_CLI: Profile = Profile {
     oauth_provider: "google",
-    base: GEMINI_CLI_BASE,
+    bases: GEMINI_CLI_BASES,
     user_agent: None,
     antigravity: false,
 };
 
 const ANTIGRAVITY: Profile = Profile {
     oauth_provider: "google-antigravity",
-    base: ANTIGRAVITY_BASE,
+    bases: ANTIGRAVITY_BASES,
     user_agent: Some(ANTIGRAVITY_USER_AGENT),
     antigravity: true,
 };
+
+/// Logical picker ids collapse to a wire id on `daily-cloudcode-pa`. Sending
+/// the family name (`gemini-3.1-pro`) 404s; the hub uses the effort member.
+fn antigravity_wire_model(model: &str) -> &str {
+    match model {
+        "gemini-3.1-pro" => "gemini-3.1-pro-low",
+        "gemini-3.1-pro-high" => "gemini-pro-agent",
+        "gemini-3.1-flash" | "gemini-3-flash" | "gemini-3.5-flash" => "gemini-3.5-flash-low",
+        "gemini-3.6-flash" => "gemini-3.6-flash-low",
+        "gemini-3.7-flash" => "gemini-3.7-flash-low",
+        other => other,
+    }
+}
 
 /// Client metadata the Code Assist service expects (Gemini CLI sends the
 /// same shape; the values label an unspecified IDE on the current platform).
@@ -108,16 +124,21 @@ fn authorize(
     }
 }
 
-/// POST `{profile.base}{path}` with the OAuth bearer token; a 401 force-renews
+fn failover_http(status: u16) -> bool {
+    matches!(status, 404 | 408 | 429 | 500 | 502 | 503 | 504)
+}
+
+/// POST `{base}{path}` with the OAuth bearer token; a 401 force-renews
 /// the stored credential once via `oauth_refresh` (Google tokens last 1h, so a
 /// revoked or early-expired token is the common failure).
-async fn post(
+async fn post_at(
     profile: &Profile,
+    base: &str,
     path: &str,
     api_key: &str,
     body: &Value,
 ) -> whycode_core::Result<reqwest::Response> {
-    let url = format!("{}{path}", profile.base);
+    let url = format!("{base}{path}");
     crate::oauth_refresh::send_with_refresh_retry(profile.oauth_provider, api_key, |key| {
         authorize(
             profile,
@@ -130,13 +151,44 @@ async fn post(
     .await
 }
 
-/// GET an LRO status (`GET {profile.base}/{operation_name}`) with the same retry.
+async fn post(
+    profile: &Profile,
+    path: &str,
+    api_key: &str,
+    body: &Value,
+) -> whycode_core::Result<reqwest::Response> {
+    post_at(profile, profile.bases[0], path, api_key, body).await
+}
+
+/// Like [`post`], but Antigravity generate/stream calls try the sandbox host
+/// when daily answers a failover status (404 is the common "this RPC isn't
+/// on this frontend" miss).
+async fn post_generate(
+    profile: &Profile,
+    path: &str,
+    api_key: &str,
+    body: &Value,
+) -> whycode_core::Result<reqwest::Response> {
+    let last = profile.bases.len() - 1;
+    for (i, base) in profile.bases.iter().enumerate() {
+        let resp = post_at(profile, base, path, api_key, body).await?;
+        if resp.status().is_success() || i == last || !failover_http(resp.status().as_u16()) {
+            return Ok(resp);
+        }
+        if let Err(error) = resp.bytes().await {
+            tracing::debug!(%error, "discarding Antigravity failover response body");
+        }
+    }
+    unreachable!("post_generate always returns inside the loop")
+}
+
+/// GET an LRO status (`GET {base}/{operation_name}`) with the same retry.
 async fn get(
     profile: &Profile,
     path: &str,
     api_key: &str,
 ) -> whycode_core::Result<reqwest::Response> {
-    let url = format!("{}{path}", profile.base);
+    let url = format!("{}{path}", profile.bases[0]);
     crate::oauth_refresh::send_with_refresh_retry(profile.oauth_provider, api_key, |key| {
         authorize(
             profile,
@@ -375,6 +427,18 @@ fn apply_antigravity_inner(inner: &mut Value, request: &LlmRequest) {
     }
 }
 
+fn antigravity_ids() -> (String, String, String) {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_millis())
+        .unwrap_or(1);
+    let agent = format!("{now:016x}");
+    let traj = format!("{:016x}", now.wrapping_mul(0x9e37_79b9_7f4a_7c15) >> 8);
+    let request_id = format!("agent/{agent}/{now}/{traj}/2");
+    let session = format!("-{}", now & ((1u128 << 63) - 1));
+    (session, request_id, traj)
+}
+
 fn wrap_envelope(
     profile: &Profile,
     model: &str,
@@ -384,12 +448,22 @@ fn wrap_envelope(
 ) -> Value {
     if profile.antigravity {
         apply_antigravity_inner(&mut inner, request);
+        let (session, request_id, traj) = antigravity_ids();
+        let claude = model.to_ascii_lowercase().contains("claude");
+        inner["sessionId"] = json!(session);
+        inner["labels"] = json!({
+            "last_step_index": "1",
+            "trajectory_id": traj,
+            "used_claude": claude.to_string(),
+            "used_claude_conservative": claude.to_string(),
+        });
         json!({
             "model": model,
             "project": project,
             "request": inner,
             "userAgent": "antigravity",
             "requestType": "agent",
+            "requestId": request_id,
         })
     } else {
         json!({
@@ -474,6 +548,11 @@ async fn complete_with(
     model: &str,
 ) -> whycode_core::Result<LlmResponse> {
     let project = project_id(profile, api_key).await?;
+    let model = if profile.antigravity {
+        antigravity_wire_model(model)
+    } else {
+        model
+    };
     let body = wrap_envelope(
         profile,
         model,
@@ -481,7 +560,7 @@ async fn complete_with(
         build_inner_request(request),
         request,
     );
-    let resp = post(profile, ":generateContent", api_key, &body).await?;
+    let resp = post_generate(profile, ":generateContent", api_key, &body).await?;
     let status = resp.status();
     let json: Value = resp
         .json()
@@ -490,7 +569,7 @@ async fn complete_with(
     if !status.is_success() {
         let msg = json["error"]["message"].as_str().unwrap_or("Unknown error");
         return Err(whycode_core::Error::Llm(format!(
-            "Code Assist error ({status}): {msg}"
+            "Code Assist error ({status}) model={model}: {msg}"
         )));
     }
     let json = if json["response"].is_object() {
@@ -562,6 +641,11 @@ async fn stream_with(
     model: &str,
 ) -> whycode_core::Result<Pin<Box<dyn Stream<Item = whycode_core::Result<StreamEvent>> + Send>>> {
     let project = project_id(profile, api_key).await?;
+    let model = if profile.antigravity {
+        antigravity_wire_model(model)
+    } else {
+        model
+    };
     let body = wrap_envelope(
         profile,
         model,
@@ -569,14 +653,14 @@ async fn stream_with(
         build_inner_request(request),
         request,
     );
-    let resp = post(profile, ":streamGenerateContent?alt=sse", api_key, &body).await?;
+    let resp = post_generate(profile, ":streamGenerateContent?alt=sse", api_key, &body).await?;
 
     if !resp.status().is_success() {
         let status = resp.status();
         let text = resp.text().await.unwrap_or_default();
         let trimmed: String = text.chars().take(500).collect();
         return Err(whycode_core::Error::Llm(format!(
-            "Code Assist error ({status}): {trimmed}"
+            "Code Assist error ({status}) model={model}: {trimmed}"
         )));
     }
 
@@ -677,11 +761,19 @@ mod tests {
             "VALIDATED"
         );
 
-        let body = wrap_envelope(&ANTIGRAVITY, "gemini-3.1-pro", "proj", inner, &request);
+        let body = wrap_envelope(&ANTIGRAVITY, "gemini-3.1-pro-low", "proj", inner, &request);
         assert_eq!(body["userAgent"], "antigravity");
         assert_eq!(body["requestType"], "agent");
         assert_eq!(body["project"], "proj");
-        assert_eq!(body["model"], "gemini-3.1-pro");
+        assert_eq!(body["model"], "gemini-3.1-pro-low");
+        assert!(
+            body["requestId"]
+                .as_str()
+                .is_some_and(|id| id.starts_with("agent/")),
+            "requestId={}",
+            body["requestId"]
+        );
+        assert!(body["request"]["sessionId"].as_str().is_some());
 
         let gemini = wrap_envelope(
             &GEMINI_CLI,
@@ -692,6 +784,26 @@ mod tests {
         );
         assert!(gemini.get("userAgent").is_none());
         assert!(gemini.get("requestType").is_none());
+    }
+
+    #[test]
+    fn antigravity_wire_model_collapses_family_ids() {
+        assert_eq!(
+            antigravity_wire_model("gemini-3.1-pro"),
+            "gemini-3.1-pro-low"
+        );
+        assert_eq!(
+            antigravity_wire_model("gemini-3.1-flash"),
+            "gemini-3.5-flash-low"
+        );
+        assert_eq!(
+            antigravity_wire_model("claude-sonnet-4-6"),
+            "claude-sonnet-4-6"
+        );
+        assert_eq!(
+            antigravity_wire_model("gemini-3.1-pro-low"),
+            "gemini-3.1-pro-low"
+        );
     }
 
     #[test]

--- a/crates/llm/src/providers/mod.rs
+++ b/crates/llm/src/providers/mod.rs
@@ -1,6 +1,7 @@
 //! Built-in LLM provider implementations.
 
 pub mod anthropic;
+pub mod antigravity;
 pub mod codeassist;
 pub mod codex;
 pub mod copilot;
@@ -161,6 +162,16 @@ mod tests {
         assert_eq!(
             p.default_base_url(),
             "https://api.githubcopilot.com/chat/completions"
+        );
+    }
+
+    #[test]
+    fn antigravity_identity() {
+        let p = antigravity::AntigravityProvider::new();
+        assert_eq!(p.name(), "google-antigravity");
+        assert_eq!(
+            p.default_base_url(),
+            "https://daily-cloudcode-pa.googleapis.com/v1internal"
         );
     }
 }

--- a/crates/llm/tests/providers.rs
+++ b/crates/llm/tests/providers.rs
@@ -1,5 +1,7 @@
 /// Integration tests for LLM provider body building, retry, and fallback.
-use whycode_core::types::{LlmRequest, Message, MessageContent, Role};
+use whycode_core::types::{
+    ContentBlock, LlmRequest, Message, MessageContent, Role, ToolDefinition,
+};
 use whycode_llm::anthropic::AnthropicProvider;
 use whycode_llm::deepseek::DeepSeekProvider;
 use whycode_llm::fallback::FallbackChain;
@@ -27,6 +29,133 @@ fn make_basic_request() -> LlmRequest {
         thinking: None,
         use_prompt_cache: true,
     }
+}
+
+const CANONICAL_CALL_ID: &str = "call_weather_1";
+
+fn make_canonical_tool_semantics_request() -> LlmRequest {
+    LlmRequest {
+        system: String::new(),
+        messages: std::sync::Arc::from(vec![
+            Message {
+                role: Role::User,
+                content: MessageContent::Text("What is the weather in Paris?".into()),
+                tool_call_id: None,
+                name: None,
+                created_at: None,
+            },
+            Message {
+                role: Role::Assistant,
+                content: MessageContent::Blocks(vec![ContentBlock::ToolUse {
+                    id: CANONICAL_CALL_ID.into(),
+                    name: "get_weather".into(),
+                    input: serde_json::json!({"city": "Paris"}),
+                }]),
+                tool_call_id: None,
+                name: None,
+                created_at: None,
+            },
+            Message {
+                role: Role::Tool,
+                content: MessageContent::Blocks(vec![ContentBlock::ToolResult {
+                    tool_use_id: CANONICAL_CALL_ID.into(),
+                    content: "21 C".into(),
+                    is_error: None,
+                }]),
+                tool_call_id: Some(CANONICAL_CALL_ID.into()),
+                name: None,
+                created_at: None,
+            },
+        ]),
+        tools: vec![ToolDefinition {
+            name: "get_weather".into(),
+            description: "Get the current weather for a city.".into(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": false
+            }),
+        }],
+        max_tokens: None,
+        temperature: None,
+        top_p: None,
+        top_k: None,
+        stop_sequences: None,
+        thinking: None,
+        use_prompt_cache: false,
+    }
+}
+
+#[test]
+fn test_public_provider_bodies_preserve_canonical_tool_semantics() {
+    let request = make_canonical_tool_semantics_request();
+    let expected_schema = serde_json::json!({
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+        "additionalProperties": false
+    });
+
+    let anthropic = AnthropicProvider::new().build_body(&request, "claude");
+    let openai = OpenAiProvider::new().build_body(&request, "gpt-4o");
+
+    let anthropic_tool = &anthropic["tools"][0];
+    assert_eq!(anthropic_tool["name"], "get_weather");
+    assert_eq!(
+        anthropic_tool["description"],
+        "Get the current weather for a city."
+    );
+    assert_eq!(anthropic_tool["input_schema"], expected_schema);
+
+    let anthropic_call = &anthropic["messages"][1]["content"][0];
+    let anthropic_result = &anthropic["messages"][2]["content"][0];
+    assert_eq!(anthropic_call["type"], "tool_use");
+    assert_eq!(anthropic_call["id"], CANONICAL_CALL_ID);
+    assert_eq!(anthropic_call["name"], anthropic_tool["name"]);
+    assert_eq!(
+        anthropic_call["input"],
+        serde_json::json!({"city": "Paris"})
+    );
+    assert_eq!(anthropic_result["type"], "tool_result");
+    assert_eq!(anthropic_result["tool_use_id"], anthropic_call["id"]);
+    assert_eq!(anthropic_result["content"], "21 C");
+
+    let openai_tool = &openai["tools"][0];
+    assert_eq!(openai_tool["type"], "function");
+    assert_eq!(openai_tool["function"]["name"], "get_weather");
+    assert_eq!(
+        openai_tool["function"]["description"],
+        "Get the current weather for a city."
+    );
+    assert_eq!(openai_tool["function"]["parameters"], expected_schema);
+
+    let openai_assistant = &openai["messages"][1];
+    let openai_call = &openai_assistant["tool_calls"][0];
+    assert_eq!(openai_assistant["role"], "assistant");
+    assert!(openai_assistant["content"].is_null());
+    assert_eq!(openai_call["id"], CANONICAL_CALL_ID);
+    assert_eq!(openai_call["type"], "function");
+    assert_eq!(
+        openai_call["function"]["name"],
+        openai_tool["function"]["name"]
+    );
+
+    let openai_arguments: serde_json::Value = serde_json::from_str(
+        openai_call["function"]["arguments"]
+            .as_str()
+            .expect("OpenAI function arguments should be a JSON string"),
+    )
+    .expect("OpenAI function arguments should contain valid JSON");
+    assert_eq!(openai_arguments, serde_json::json!({"city": "Paris"}));
+
+    let openai_result = &openai["messages"][2];
+    assert_eq!(openai_result["role"], "tool");
+    assert_eq!(openai_result["tool_call_id"], openai_call["id"]);
+    assert_eq!(
+        openai_result["content"],
+        "[tool_result call_weather_1] 21 C"
+    );
 }
 
 // ─── Anthropic body building ───────────────────────────────────────────────

--- a/crates/memory/src/service.rs
+++ b/crates/memory/src/service.rs
@@ -220,7 +220,8 @@ impl MemoryService {
         }
         const MAX: usize = 2000;
         if clip.len() > MAX {
-            clip.truncate(MAX);
+            // Byte cap can land inside a multibyte char; String::truncate panics.
+            clip.truncate(clip.floor_char_boundary(MAX));
         }
         let vec = self.embed_text(&clip);
         let blob = encode_blob(&vec);
@@ -904,14 +905,32 @@ mod tests {
         svc.index_session_turn("blank", 0, " \n", "\t").unwrap();
         svc.index_session_turn("long-session", 3, &"x".repeat(2500), "tail")
             .unwrap();
+        // "User: " (6) + 1993 ASCII + 2-byte `ç` + `\n` = 2002. Byte 2000 sits
+        // inside `ç`; String::truncate(2000) used to panic (crash-20260823).
+        svc.index_session_turn("utf8-session", 4, &format!("{}ç", "a".repeat(1993)), "")
+            .unwrap();
         let rows = svc
             .open_db()
             .unwrap()
             .list_session_chunks(&svc.bank_key, 10)
             .unwrap();
-        assert_eq!(rows.len(), 1);
-        assert_eq!(rows[0].text.len(), 2000);
-        assert!(rows[0].text.starts_with("User: "));
+        assert_eq!(rows.len(), 2);
+        let ascii = rows
+            .iter()
+            .find(|r| r.session_id == "long-session")
+            .unwrap();
+        assert_eq!(ascii.text.len(), 2000);
+        assert!(ascii.text.starts_with("User: "));
+        let utf8 = rows
+            .iter()
+            .find(|r| r.session_id == "utf8-session")
+            .unwrap();
+        assert!(utf8.text.is_char_boundary(utf8.text.len()));
+        assert!(utf8.text.len() <= 2000);
+        assert!(
+            !utf8.text.contains('ç'),
+            "multibyte tail must be dropped rather than splitting the char"
+        );
     }
 
     #[test]

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -1697,6 +1697,7 @@ fn open_provider_dialog(app: &mut TuiApp) {
         "anthropic",
         "openai",
         "google",
+        "google-antigravity",
         "groq",
         "deepseek",
         "mistral",

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -1214,11 +1214,16 @@ Two silent-failure traps when onboarding a fresh Google token via
    `userDefinedCloudaicompanionProject: true` tier (`standard-tier`) in
    `loadCodeAssist.allowedTiers`. Forcing `free-tier` returns **403 Forbidden**
    ("not eligible for individuals"). Pick the user-defined-project tier first.
-2. **LRO result.** The operation can take minutes; polling for ~10 s then
-   reading `response.cloudaicompanionProject.id` fails with "no project id"
-   even though provisioning would succeed. Also, `cloudaicompanionProject`
-   ships as **both** an object (`{"id": …}`) and a bare string — accept both.
-   Standard-tier calls should pass `cloudaicompanionProject` in the request
-   body when the caller has one.
+2. **LRO result & project resolution.** The operation can take minutes;
+   polling for ~10 s then reading `response.cloudaicompanionProject.id` fails
+   with "no project id". Two subtleties confirmed by diffing oh-my-pi's proven
+   implementation (`packages/ai/src/registry/oauth/google-antigravity.ts`):
+   accounts whose `loadCodeAssist` response carries a `currentTier` are ALREADY
+   onboarded — never call `onboardUser` for them; and the authoritative source
+   of the project is a **fresh** `:loadCodeAssist` call after provisioning,
+   where `cloudaicompanionProject` ships as a bare **string** (the LRO body
+   frequently carries no project at all). Also surface
+   `ineligibleTiers[].reasonMessage` before attempting free-tier onboarding —
+   it is Google's own explanation for the 403.
 
 Debugged 2026-08-24 after real-world 403 → "did not yield a project id" reports.

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -140,6 +140,26 @@ Only bump a budget in the **same commit**, and say why. If the count is *below* 
 
 ## Log
 
+### 2026-08-23 — `String::truncate` panics mid-UTF-8 in session memory
+
+**Symptom:** TUI abort: `assertion failed: self.is_char_boundary(new_len)` at
+`crates/memory/src/service.rs` while indexing a turn. Crash file
+`crash-20260823T214444.033.txt`.
+
+**JSONL / crash:** panic in `tokio-rt-worker`; location is the 2000-byte clip
+in `MemoryService::index_session_turn`.
+
+**Root cause:** `clip.truncate(2000)` is a **byte** cap. A 2-byte char
+(`ç`, emoji, CJK) that straddles offset 2000 is not a char boundary;
+`String::truncate` asserts.
+
+**Fix:** `clip.truncate(clip.floor_char_boundary(MAX))`. Test uses a
+payload whose 2000th byte sits inside `ç`.
+
+**Prevention:** Never `String::truncate(n)` / `&s[..n]` on user text
+without `is_char_boundary` / `floor_char_boundary`. Byte length ≠ char
+length.
+
 ### 2026-08-20 — core 100% floor misses `save_todos` parent `if let`
 
 **Symptom:** `Coverage (line floor)` fails `whycode-core` with

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -1210,16 +1210,20 @@ static-suffix route on the same path pattern is rejected.
 **Symptom:** `google-antigravity` browser sign-in succeeds, then fails with
 `Google Code Assist: This client is no longer supported for Gemini Code Assist`.
 
-**Cause:** Native Antigravity requests `cclog` + `experimentsandconfigs` in
-addition to `cloud-platform` / userinfo. Without those scopes,
+**Cause:** Native Antigravity (and oh-my-pi's working client) request
+`cclog` + `experimentsandconfigs` in addition to `cloud-platform` / userinfo,
+identify as `antigravity/hub/2.8.0 (aidev_client; os_type=darwin; arch=arm64;
+cl=963137146)` regardless of host OS, and poll `:onboardUser` LROs with GET.
+Without the extra scopes or with a Linux/x86_64 User-Agent,
 `loadCodeAssist` classifies the session as Gemini Code Assist for individuals
 (sunset 2026-06-18) and puts `free-tier` in `ineligibleTiers`. A second trap:
 that ineligibility is expected even for a valid Antigravity account that still
 has `standard-tier` (or another paid tier) in `allowedTiers` — aborting on
 the free-tier reason skips the working onboard path.
 
-**Fix:** request the native five-scope set; only surface free-tier
-ineligibility when `allowedTiers` is empty.
+**Fix:** request the native five-scope set; pin the darwin/arm64 User-Agent;
+poll operations with GET; only surface free-tier ineligibility when
+`allowedTiers` is empty.
 
 ## Code Assist onboarding: LRO polling and response shapes
 

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -1202,3 +1202,23 @@ static-suffix route on the same path pattern is rejected.
 **Fix:** one route `/s/:id` and dispatch on whether `id` ends with `.json` / `.md`
 (`share_dispatch` in `crates/server/src/routes.rs`).
 
+
+## Code Assist onboarding: LRO polling and response shapes
+
+**Date:** 2026-08-24 · **Area:** `crates/auth/src/cca.rs` (google-antigravity OAuth)
+
+Two silent-failure traps when onboarding a fresh Google token via
+`:onboardUser` (`cloudcode-pa.googleapis.com/v1internal`):
+
+1. **Tier choice.** Pro/paid accounts report only the
+   `userDefinedCloudaicompanionProject: true` tier (`standard-tier`) in
+   `loadCodeAssist.allowedTiers`. Forcing `free-tier` returns **403 Forbidden**
+   ("not eligible for individuals"). Pick the user-defined-project tier first.
+2. **LRO result.** The operation can take minutes; polling for ~10 s then
+   reading `response.cloudaicompanionProject.id` fails with "no project id"
+   even though provisioning would succeed. Also, `cloudaicompanionProject`
+   ships as **both** an object (`{"id": …}`) and a bare string — accept both.
+   Standard-tier calls should pass `cloudaicompanionProject` in the request
+   body when the caller has one.
+
+Debugged 2026-08-24 after real-world 403 → "did not yield a project id" reports.

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -1203,6 +1203,24 @@ static-suffix route on the same path pattern is rejected.
 (`share_dispatch` in `crates/server/src/routes.rs`).
 
 
+## Antigravity OAuth: missing scopes look like Gemini Code Assist sunset
+
+**Date:** 2026-08-24 · **Area:** `crates/auth/src/providers.rs`, `crates/auth/src/cca.rs`
+
+**Symptom:** `google-antigravity` browser sign-in succeeds, then fails with
+`Google Code Assist: This client is no longer supported for Gemini Code Assist`.
+
+**Cause:** Native Antigravity requests `cclog` + `experimentsandconfigs` in
+addition to `cloud-platform` / userinfo. Without those scopes,
+`loadCodeAssist` classifies the session as Gemini Code Assist for individuals
+(sunset 2026-06-18) and puts `free-tier` in `ineligibleTiers`. A second trap:
+that ineligibility is expected even for a valid Antigravity account that still
+has `standard-tier` (or another paid tier) in `allowedTiers` — aborting on
+the free-tier reason skips the working onboard path.
+
+**Fix:** request the native five-scope set; only surface free-tier
+ineligibility when `allowedTiers` is empty.
+
 ## Code Assist onboarding: LRO polling and response shapes
 
 **Date:** 2026-08-24 · **Area:** `crates/auth/src/cca.rs` (google-antigravity OAuth)


### PR DESCRIPTION
## Summary

Closes the remaining work on `feature/clarification-policy` and lands the rest of the branch onto `main`.

### Clarification policy (this last commit)
- Plan-shaped asks (`create a roadmap`, `what's the best approach`, `write a migration plan`) classify as **Plan**, not Change/Question.
- Mutating tools in a **Plan** turn always Confirm — a plan is not permission to start implementation.
- `intent_guidance=always` + **Ambiguous** also Confirms mutating tools.
- Semantic behavior corpus ratchet is now **32/32** (the ignored desired-contract test is enabled).

### Also on this branch
- **google-antigravity** Code Assist provider: native OAuth scopes, hub User-Agent, daily control-plane, onboarding, wire model ids (`gemini-3.1-pro-low` / `gemini-3.5-flash-low`), sandbox failover.
- Session clip truncation on UTF-8 character boundaries.
- Ignore `.claude/` agent worktrees.

## Test plan
- [x] `cargo test -p whycode-agent --lib`
- [x] `cargo clippy -p whycode-agent --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] panic / swallowed-error / dependency-boundary ratchets