### PR TITLE
docs: surface google-antigravity login in CLI and auth docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,12 @@ whycode -P openai -m gpt-4o generate "Refactor this module"
 Or sign in with a subscription instead of an API key:
 
 ```bash
-whycode auth login anthropic        # Claude Pro/Max
-whycode auth login openai           # ChatGPT Plus/Pro
+whycode auth login anthropic              # Claude Pro/Max
+whycode auth login openai                 # ChatGPT Plus/Pro
 whycode auth login github-copilot
-whycode auth login google           # Gemini
+whycode auth login google                 # Gemini
+whycode auth login google-antigravity     # Antigravity (Gemini 3, Claude, GPT-OSS)
+whycode auth login xai                    # SuperGrok / X Premium
 ```
 
 Full CLI, TUI keys, slash commands, agents, tools and configuration:

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3426,7 +3426,8 @@ async fn cmd_provider(cmd: &ProviderCmd) -> anyhow::Result<()> {
                 println!("  whycode provider add <name> --api-key <key> --base-url <url>");
                 println!();
                 println!(
-                    "Built-in providers supported: openai, anthropic, deepseek, google, groq, xai"
+                    "Built-in providers supported: {}",
+                    whycode_llm::ProviderRegistry::default().names().join(", ")
                 );
             } else {
                 println!("{} Configured providers:", "🔑".bold());

--- a/crates/cli/tests/cli_args.rs
+++ b/crates/cli/tests/cli_args.rs
@@ -160,6 +160,12 @@ fn test_provider_list() {
     assert_ok(&["provider", "list"], &o);
     let s = String::from_utf8_lossy(&o.stdout);
     assert!(!s.is_empty(), "provider list output empty");
+    if s.contains("Built-in providers supported:") {
+        assert!(
+            s.contains("google-antigravity"),
+            "empty provider list should name google-antigravity: {s}"
+        );
+    }
 }
 
 #[test]

--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -47,6 +47,13 @@ impl ProviderRegistry {
         self.providers.get(name).map(|p| p.as_ref())
     }
 
+    /// Sorted built-in (and later config-registered) provider ids.
+    pub fn names(&self) -> Vec<String> {
+        let mut names: Vec<_> = self.providers.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
     /// Register a custom provider from config.
     /// This enables dynamically-added providers from config.toml.
     pub fn register_from_config(&mut self, config: &whycode_config::Config) {
@@ -141,6 +148,11 @@ mod tests {
             assert!(registry.get(name).is_some(), "{name} missing");
         }
         assert!(registry.get("nope").is_none());
+        let names = registry.names();
+        assert!(names.contains(&"google-antigravity".to_string()));
+        let mut sorted = names.clone();
+        sorted.sort();
+        assert_eq!(names, sorted);
     }
 
     #[test]

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -5,7 +5,8 @@ whycode accepts two credential kinds per provider:
 1. **API keys** — env var (`ANTHROPIC_API_KEY`, …) or `api_key` in `config.toml`.
 2. **OAuth subscription login** — `whycode auth login <provider>` stores a
    token from an existing subscription (Claude Pro/Max, ChatGPT Plus/Pro,
-   GitHub Copilot, Google/Gemini, xAI SuperGrok / X Premium).
+   GitHub Copilot, Google/Gemini, Google Antigravity, xAI SuperGrok / X
+   Premium).
 
 Resolution order is always: **env var → config `api_key` → OAuth store**.
 An explicit key therefore never loses to a stored subscription login.
@@ -13,11 +14,12 @@ An explicit key therefore never loses to a stored subscription login.
 ## Commands
 
 ```bash
-whycode auth login anthropic          # browser sign-in (Claude Pro/Max)
-whycode auth login openai             # browser sign-in (ChatGPT Plus/Pro)
-whycode auth login github-copilot     # device code on github.com
-whycode auth login google             # browser sign-in (Gemini)
-whycode auth login xai                # browser sign-in (SuperGrok / X Premium)
+whycode auth login anthropic              # browser sign-in (Claude Pro/Max)
+whycode auth login openai                 # browser sign-in (ChatGPT Plus/Pro)
+whycode auth login github-copilot         # device code on github.com
+whycode auth login google                 # browser sign-in (Gemini)
+whycode auth login google-antigravity     # browser sign-in (Antigravity)
+whycode auth login xai                    # browser sign-in (SuperGrok / X Premium)
 whycode auth login <p> --no-browser   # print the URL instead of opening it
 whycode auth status                   # who is logged in (never prints tokens)
 whycode auth logout <provider>        # remove stored credential
@@ -59,6 +61,7 @@ community CLIs — whycode has no registered client of its own.
 | `openai` | PKCE → loopback callback on the registered port `localhost:1455` | ✅ yes — JWT-shaped subscription tokens are routed to the Codex backend (`chatgpt.com/backend-api/codex/responses`, Responses API) with the stored `chatgpt-account-id`; API keys keep the `api.openai.com` chat-completions path (`crates/llm/src/codex.rs`) |
 | `github-copilot` | GitHub device-code grant → GitHub token is exchanged for the short-lived Copilot API token | ✅ yes — `github-copilot` provider calls `api.githubcopilot.com/chat/completions`; the Copilot token re-exchanges automatically near expiry |
 | `google` | PKCE → loopback callback on an ephemeral port | ✅ yes — `ya29.…` OAuth tokens are routed to the Code Assist endpoint (`cloudcode-pa.googleapis.com/v1internal`) with `loadCodeAssist`/`onboardUser` project discovery (`GOOGLE_CLOUD_PROJECT` overrides); `AIza…` API keys keep the `generativelanguage` route (`crates/llm/src/codeassist.rs`) |
+| `google-antigravity` | PKCE → loopback callback on the native hub port `127.0.0.1:51121` (`/oauth-callback`); Antigravity client id + scopes (`cclog`, `experimentsandconfigs`) | ✅ yes — tokens go to `daily-cloudcode-pa.googleapis.com` with `ideType: ANTIGRAVITY` and the hub User-Agent. Picker ids such as `gemini-3.1-pro` remap to hub wire ids (`gemini-3.1-pro-low`). Distinct from `google` (Gemini CLI / Code Assist sunset for consumer accounts). |
 | `xai` | PKCE → loopback callback on an ephemeral `127.0.0.1` port (`/callback`); public Grok Build client | ✅ yes — SuperGrok / X Premium tokens go to `cli-chat-proxy.grok.com` with `X-XAI-Token-Auth: xai-grok-cli` (the public Grok client path). Console keys (`xai-…`) stay on `api.x.ai` (`crates/llm/src/providers/xai.rs`) |
 
 Expired access tokens refresh transparently on next use (GitHub's token

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -372,9 +372,10 @@ generates one). It is injected into the system prompt automatically.
 
 ### Subscription login
 
-`whycode auth login` signs in with an existing subscription. Resolution
-order is env var → config `api_key` → OAuth store, so an explicit key
-always wins. Details: [auth.md](auth.md).
+`whycode auth login` signs in with an existing subscription
+(`anthropic`, `openai`, `github-copilot`, `google`, `google-antigravity`,
+`xai`). Resolution order is env var → config `api_key` → OAuth store, so
+an explicit key always wins. Details: [auth.md](auth.md).
 
 ### Themes
 


### PR DESCRIPTION
## Summary

Leftover from the Antigravity landing: the provider worked, but users could not see it.

- `whycode provider list` (empty config) now prints live builtin ids from `ProviderRegistry`, including `google-antigravity`.
- README, `docs/auth.md`, and `docs/guide.md` document `whycode auth login google-antigravity` (distinct from Gemini CLI `google`).
- Tripwire: empty provider-list output must name `google-antigravity`.

## Test plan
- [x] `cargo test -p whycode-llm --lib default_registry_exposes_builtin_providers`
- [x] `cargo test -p whycode-cli --test cli_args test_provider_list -- --exact`
- [x] clippy, fmt, budget ratchets