### PR TITLE
fix(tui): align sticky panels, scrollbar, and chat on one body column

### DIFF
--- a/crates/tools/src/web/browser.rs
+++ b/crates/tools/src/web/browser.rs
@@ -718,7 +718,7 @@ mod tests {
             assert!(handshake.starts_with("GET /devtools/page/1 HTTP/1.1\r\n"));
             assert!(handshake.contains(&format!("Host: {addr}\r\n")));
             assert!(handshake.contains("Upgrade: websocket\r\n"));
-            assert!(handshake.contains("Sec-WebSocket-Key: d2h5Y29kZS1jZHAta2V5ISE=\r\n"));
+            assert!(handshake.contains("Sec-WebSocket-Key: d2h5Y29kZXMtY2RwLWtleSEh\r\n"));
             stream
                 .write_all(b"HTTP/1.1 101 Switching Protocols\r\n\r\n")
                 .expect("write WebSocket handshake");

--- a/crates/tui/src/theme/tokens.rs
+++ b/crates/tui/src/theme/tokens.rs
@@ -68,6 +68,8 @@ pub mod layout {
     pub const TOP_PAD: u16 = 2;
     /// Blank rows between the transcript and the turn-status / prompt.
     pub const CHAT_GAP: u16 = 1;
+    /// Blank rows between sticky panels (subagent strip / todos) and the transcript.
+    pub const PANEL_GAP: u16 = 1;
     /// Gap under the prompt (bottom breathing room inside body).
     pub const BOTTOM_PAD: u16 = 1;
     /// Terminal edge insets (all four sides).
@@ -75,8 +77,6 @@ pub mod layout {
     pub const SAFE_BOTTOM: u16 = 1;
     pub const SAFE_LEFT: u16 = 1;
     pub const SAFE_RIGHT: u16 = 1;
-    /// Extra gap after a user message block.
-    pub const USER_PAD: u16 = 1;
     /// Shared left gutter for tools / epilogue / meta under an assistant turn.
     pub const ASSISTANT_PAD: u16 = 2;
     /// Sidebar preferred width (clamped by terminal size at render time).
@@ -182,6 +182,7 @@ mod tests {
             assert!(layout::PROMPT_MIN_WIDTH >= 8);
             assert!(layout::SIDEBAR_MIN_BODY > layout::SIDEBAR_MIN_CHAT);
             assert!(layout::CHAT_GAP >= 1);
+            assert!(layout::PANEL_GAP >= 1);
         }
     }
 

--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -5,7 +5,7 @@
 use crate::app::{ChatBlock, ChatRole, TuiApp};
 use crate::theme::ThemePalette;
 use crate::tokens::{HOME_LOGO_CODE, HOME_LOGO_WHY, layout};
-use crate::ui::scrollbar::{SCROLLBAR_GUTTER, ScrollbarColors, paint_scrollbar};
+use crate::ui::scrollbar::{SCROLLBAR_GAP, SCROLLBAR_GUTTER, ScrollbarColors, paint_scrollbar};
 use crate::widgets::wrap::wrap_text;
 #[cfg(test)]
 use ratatui::widgets::Widget;
@@ -274,14 +274,15 @@ fn render_home(frame: &mut Frame, area: Rect, app: &TuiApp, palette: &ThemePalet
 
 fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &ThemePalette) {
     // Shell already applies SIDE_PAD — don't pad again (extra spaces end up in mouse selection).
-    // When the transcript overflows, reserve a dedicated right-hand gutter so
+    // When the transcript overflows, reserve a blank gap + the 1-col bar so
     // the solid scrollbar never paints over wrapped text.
     let height = area.height as usize;
     let full_width = area.width;
+    let reserved = SCROLLBAR_GUTTER.saturating_add(SCROLLBAR_GAP);
     let (starts_full, total_full) = message_row_layout_mut(app, full_width);
-    let mut needs_bar = total_full > height && area.width > SCROLLBAR_GUTTER;
+    let mut needs_bar = total_full > height && area.width > reserved;
     let mut content_width = if needs_bar {
-        full_width.saturating_sub(SCROLLBAR_GUTTER)
+        full_width.saturating_sub(reserved)
     } else {
         full_width
     };
@@ -422,6 +423,14 @@ fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &The
         // so "at bottom" never looked like the bottom. Ours maps
         // top-origin `view_start` with `thumb_pos = view_start * travel / max_off`,
         // matching drag math in `ui/scrollbar` (0 → top, max_off → flush bottom).
+        let gap_x = area.x.saturating_add(content_width);
+        let clear = Style::default().fg(palette.bg).bg(palette.bg);
+        for dy in 0..area.height {
+            if let Some(cell) = buf.cell_mut((gap_x, area.y.saturating_add(dy))) {
+                cell.set_symbol(" ");
+                cell.set_style(clear);
+            }
+        }
         let sb = Rect {
             x: area.x + area.width.saturating_sub(SCROLLBAR_GUTTER),
             y: area.y,
@@ -430,7 +439,7 @@ fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &The
         };
         let colors = ScrollbarColors::from_palette(palette);
         paint_scrollbar(
-            frame.buffer_mut(),
+            buf,
             sb,
             total,
             height,

--- a/crates/tui/src/ui/chat_scroll_tests.rs
+++ b/crates/tui/src/ui/chat_scroll_tests.rs
@@ -696,8 +696,8 @@ fn paint_publishes_scrollbar_when_overflowing() {
     assert_eq!(hit.x + hit.width, 40, "bar sits on the right edge");
     assert_eq!(
         app.chat_content_width,
-        40 - crate::ui::scrollbar::SCROLLBAR_GUTTER,
-        "text wrap must reserve the scrollbar gutter"
+        40 - crate::ui::scrollbar::SCROLLBAR_GUTTER - crate::ui::scrollbar::SCROLLBAR_GAP,
+        "text wrap must reserve the scrollbar gap + gutter"
     );
 }
 
@@ -767,8 +767,16 @@ fn overflowing_chat_does_not_paint_text_under_scrollbar() {
     assert_eq!(hit.width, crate::ui::scrollbar::SCROLLBAR_GUTTER);
     assert_eq!(
         app.chat_content_width,
-        w - crate::ui::scrollbar::SCROLLBAR_GUTTER
+        w - crate::ui::scrollbar::SCROLLBAR_GUTTER - crate::ui::scrollbar::SCROLLBAR_GAP
     );
+    for y in 0..h {
+        let gap = buf.cell((bar_x.saturating_sub(1), y)).expect("gap cell");
+        assert_eq!(
+            gap.symbol(),
+            " ",
+            "column left of the bar must be the blank gap at y={y}"
+        );
+    }
 }
 
 #[test]

--- a/crates/tui/src/ui/render.rs
+++ b/crates/tui/src/ui/render.rs
@@ -223,8 +223,28 @@ fn render_shell(frame: &mut Frame, app: &mut TuiApp, palette: &ThemePalette) {
     let body = layout::below_header(outer[1]);
     status::render_footer(frame, outer[2], app, palette);
 
+    // Home never renders the sidebar, so its shared column is plain side_pad;
+    // the session path must subtract the sidebar rail before picking the pad.
+    let side = if app.messages.is_empty() {
+        layout::side_pad(body.width)
+    } else {
+        session_side_pad(app, body)
+    };
     let strip_h = subagents::strip_height(app);
-    let todo_h = todos::panel_height(app, body.height.saturating_sub(strip_h));
+    // Reserve PANEL_GAP in the todo budget so the transcript still gets ≥ 3 rows.
+    let todo_h = todos::panel_height(
+        app,
+        body.height
+            .saturating_sub(strip_h)
+            .saturating_sub(layout::PANEL_GAP),
+    );
+    // Drop the gap row on tiny bodies (e.g. strip-only at height 3-4) instead
+    // of letting it squeeze the transcript below its 3-row minimum.
+    let gap_h = if body.height >= strip_h + todo_h + layout::PANEL_GAP + 3 {
+        layout::PANEL_GAP
+    } else {
+        0
+    };
     let (strip, todo_area, body) = if strip_h == 0 && todo_h == 0 {
         (None, None, body)
     } else {
@@ -235,6 +255,7 @@ fn render_shell(frame: &mut Frame, app: &mut TuiApp, palette: &ThemePalette) {
         if todo_h > 0 {
             constraints.push(Constraint::Length(todo_h));
         }
+        constraints.push(Constraint::Length(gap_h));
         constraints.push(Constraint::Min(3));
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -255,13 +276,16 @@ fn render_shell(frame: &mut Frame, app: &mut TuiApp, palette: &ThemePalette) {
         } else {
             None
         };
+        let gap_area = chunks[i];
+        i += 1;
+        super::layout::fill_blank(frame, gap_area, palette.bg);
         (strip, todo_area, chunks[i])
     };
     if let Some(area) = strip {
-        subagents::render_strip(frame, area, app, palette);
+        subagents::render_strip(frame, area, app, palette, side);
     }
     if let Some(area) = todo_area {
-        todos::render_panel(frame, area, app, palette);
+        todos::render_panel(frame, area, app, palette, side);
     } else {
         app.todos_hit.clear();
     }
@@ -337,15 +361,30 @@ fn render_home(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &ThemeP
     file_suggest::render(frame, chunks[3], app, palette);
 }
 
+/// Sidebar rail width when it fits beside the chat; `None` hides it.
+fn session_sidebar_width(app: &TuiApp, area: Rect) -> Option<u16> {
+    let rail = layout::SIDEBAR_WIDTH.min(area.width / 3).max(24);
+    let fits = area.width >= layout::SIDEBAR_MIN_BODY
+        && area.width.saturating_sub(rail) >= layout::SIDEBAR_MIN_CHAT;
+    if app.sidebar.visible && fits {
+        Some(rail)
+    } else {
+        None
+    }
+}
+
+/// Horizontal pad shared by sticky panels, transcript, and prompt.
+fn session_side_pad(app: &TuiApp, area: Rect) -> u16 {
+    let main_width = match session_sidebar_width(app, area) {
+        Some(w) => area.width.saturating_sub(w),
+        None => area.width,
+    };
+    layout::side_pad(main_width)
+}
+
 /// session: optional sidebar + padded main column
 fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &ThemePalette) {
-    let sidebar_fits = area.width >= layout::SIDEBAR_MIN_BODY
-        && area
-            .width
-            .saturating_sub(layout::SIDEBAR_WIDTH.min(area.width / 3).max(24))
-            >= layout::SIDEBAR_MIN_CHAT;
-    let main = if app.sidebar.visible && sidebar_fits {
-        let w = layout::SIDEBAR_WIDTH.min(area.width / 3).max(24);
+    let main = if let Some(w) = session_sidebar_width(app, area) {
         let chunks = Layout::default()
             .direction(Direction::Horizontal)
             .constraints([Constraint::Min(20), Constraint::Length(w)])
@@ -357,7 +396,7 @@ fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &The
         area
     };
 
-    let side = layout::side_pad(main.width);
+    let side = session_side_pad(app, area);
     let inset = Rect {
         x: main.x.saturating_add(side),
         y: main.y,
@@ -1431,6 +1470,100 @@ mod paint_tests {
         assert!(
             top.contains(':'),
             "sticky header must keep the clock: {top:?}"
+        );
+    }
+
+    fn first_non_space_x(buf: &ratatui::buffer::Buffer, y: u16) -> Option<u16> {
+        let area = buf.area();
+        (area.x..area.x.saturating_add(area.width)).find(|&x| {
+            buf.cell((x, y))
+                .is_some_and(|c| c.symbol() != " " && !c.symbol().is_empty())
+        })
+    }
+
+    #[test]
+    fn sticky_todo_panel_aligns_with_chat_and_leaves_gaps() {
+        let mut a = session_with_overflow();
+        a.replace_todos(vec![whycodes_core::TodoItem::new(
+            "a",
+            "ALIGN_TODO_MARKER pending work",
+            whycodes_core::TodoStatus::Pending,
+        )]);
+        let (buf, _text) = paint_full_shell(&mut a, 100, 24);
+
+        let header = a.todos_hit.rect.expect("todo header hit");
+        let chat = a.chat_area.expect("chat hit");
+        let bar = a.chat_scrollbar_hit.expect("overflowing chat paints a bar");
+
+        let header_row = row_text(&buf, header.y);
+        assert!(
+            header_row.contains("Todos"),
+            "todo header missing: {header_row:?}"
+        );
+        let todo_x = first_non_space_x(&buf, header.y).expect("todo header text");
+        assert_eq!(
+            todo_x, chat.x,
+            "todo header must start on the chat body column (todo_x={todo_x} chat.x={})",
+            chat.x
+        );
+
+        assert!(
+            chat.y >= header.y + 2 + layout::PANEL_GAP,
+            "chat.y={} must sit below todo panel + PANEL_GAP (header.y={})",
+            chat.y,
+            header.y
+        );
+        let gap_y = chat.y.saturating_sub(1);
+        let gap = row_text(&buf, gap_y);
+        assert!(
+            !gap.contains("Todos") && !gap.contains("ALIGN_TODO_MARKER") && !gap.contains('❯'),
+            "blank row between todos and transcript: {gap:?}"
+        );
+        assert!(
+            gap.chars().all(|c| c == ' ' || c == '\n'),
+            "panel gap row must be empty: {gap:?}"
+        );
+
+        assert_eq!(
+            bar.x + bar.width,
+            chat.x + chat.width,
+            "bar on last chat col"
+        );
+        let gap_col = bar.x.saturating_sub(1);
+        for y in chat.y..chat.y.saturating_add(chat.height) {
+            let cell = buf.cell((gap_col, y)).expect("gap col");
+            assert_eq!(
+                cell.symbol(),
+                " ",
+                "column left of scrollbar must be blank at y={y}"
+            );
+        }
+    }
+
+    #[test]
+    fn tiny_body_drops_panel_gap_to_keep_the_transcript() {
+        let mut a = session_with_overflow();
+        a.upsert_subagent(crate::app::SubagentUpdate {
+            id: "task-1".into(),
+            kind: "explore".into(),
+            description: "scan".into(),
+            status: "running".into(),
+            activity: "Thinking".into(),
+            elapsed_ms: 0,
+            output: String::new(),
+        });
+        // 100x10 → 4 body rows after safe insets, header/footer, and TOP_PAD:
+        // strip(1) + PANEL_GAP would leave the transcript under its 3-row
+        // minimum, so the gap row must be dropped.
+        let (_buf, _) = paint_full_shell(&mut a, 100, 10);
+        let strip = a.subagent_strip_hit.first().expect("strip painted").0;
+        let chat = a.chat_area.expect("chat hit");
+        assert_eq!(
+            chat.y,
+            strip.y + 1,
+            "tiny body must not spend a row on PANEL_GAP (strip.y={} chat.y={})",
+            strip.y,
+            chat.y
         );
     }
 }

--- a/crates/tui/src/ui/scrollbar.rs
+++ b/crates/tui/src/ui/scrollbar.rs
@@ -10,8 +10,10 @@ use ratatui::{
     style::{Color, Style},
 };
 
-/// Columns reserved for the scrollbar track when content overflows.
+/// Width of the scrollbar track itself (last column of the area).
 pub const SCROLLBAR_GUTTER: u16 = 1;
+/// Blank column between transcript text and the bar when a scrollbar shows.
+pub const SCROLLBAR_GAP: u16 = 1;
 
 /// Track / thumb pair derived from the active palette.
 #[derive(Clone, Copy)]
@@ -78,7 +80,8 @@ pub fn paint_scrollbar(
 
 /// Paint a scrollbar on the right edge of `area` when `total > visible`.
 ///
-/// Returns the content rect (full width if no bar, else width − gutter).
+/// Returns the content rect (full width if no bar, else width − gap − gutter).
+/// The 1-col bar stays in the last column of `area`.
 pub fn content_with_scrollbar(
     buf: &mut Buffer,
     area: Rect,
@@ -93,7 +96,9 @@ pub fn content_with_scrollbar(
     let content = Rect {
         x: area.x,
         y: area.y,
-        width: area.width.saturating_sub(SCROLLBAR_GUTTER),
+        width: area
+            .width
+            .saturating_sub(SCROLLBAR_GUTTER.saturating_add(SCROLLBAR_GAP)),
         height: area.height,
     };
     let sb = Rect {

--- a/crates/tui/src/ui/subagents.rs
+++ b/crates/tui/src/ui/subagents.rs
@@ -17,7 +17,13 @@ pub fn strip_height(app: &TuiApp) -> u16 {
     if app.has_subagent_strip() { 1 } else { 0 }
 }
 
-pub fn render_strip(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &ThemePalette) {
+pub fn render_strip(
+    frame: &mut Frame,
+    area: Rect,
+    app: &mut TuiApp,
+    palette: &ThemePalette,
+    side: u16,
+) {
     app.subagent_strip_hit.clear();
     if area.height == 0 || app.subagents.is_empty() {
         return;
@@ -44,8 +50,14 @@ pub fn render_strip(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &T
         .find(|s| s.is_running())
         .or_else(|| app.subagents.last());
 
-    let mut spans = vec![Span::styled(
-        format!(" {count} "),
+    // The count badge starts exactly on the shared body column (no hidden
+    // leading space, or the strip sits one col right of the chat text).
+    let mut spans = Vec::new();
+    if side > 0 {
+        spans.push(Span::raw(" ".repeat(side as usize)));
+    }
+    spans.push(Span::styled(
+        format!("{count} "),
         Style::default()
             .fg(if running > 0 {
                 palette.accent
@@ -53,7 +65,7 @@ pub fn render_strip(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &T
                 palette.dim
             })
             .add_modifier(Modifier::BOLD),
-    )];
+    ));
     if let Some(row) = focus {
         spans.push(Span::styled("· ", Style::default().fg(palette.dim)));
         spans.push(Span::styled(
@@ -67,6 +79,7 @@ pub fn render_strip(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &T
             ));
         }
         spans.push(Span::styled("  Ctrl+G", Style::default().fg(palette.dim)));
+        // Hit target stays full-width even though the label is indented.
         app.subagent_strip_hit.push((area, row.id.clone()));
     }
 
@@ -181,7 +194,7 @@ mod tests {
         let backend = TestBackend::new(w, h);
         let mut terminal = Terminal::new(backend).expect("term");
         terminal
-            .draw(|f| render_strip(f, f.area(), app, &palette))
+            .draw(|f| render_strip(f, f.area(), app, &palette, 0))
             .expect("draw");
         let buf = terminal.backend().buffer().clone();
         let mut out = String::new();
@@ -223,6 +236,39 @@ mod tests {
         assert!(text.contains("explore"), "{text}");
         assert!(text.contains("scan the crate"), "{text}");
         assert!(text.contains("Ctrl+G"), "{text}");
+    }
+
+    #[test]
+    fn strip_indents_text_by_side_and_keeps_full_width_hit() {
+        let mut app = TuiApp::new(TuiAppConfig::default());
+        app.upsert_subagent(crate::app::SubagentUpdate {
+            id: "task-1".into(),
+            kind: "explore".into(),
+            description: "scan the crate".into(),
+            status: "running".into(),
+            activity: "Thinking".into(),
+            elapsed_ms: 0,
+            output: String::new(),
+        });
+        let palette = app.config.palette();
+        let backend = TestBackend::new(80, 1);
+        let mut terminal = Terminal::new(backend).expect("term");
+        terminal
+            .draw(|f| render_strip(f, f.area(), &mut app, &palette, 2))
+            .expect("draw");
+        let buf = terminal.backend().buffer().clone();
+        let mut row = String::new();
+        for x in 0..buf.area().width {
+            if let Some(c) = buf.cell((x, 0)) {
+                row.push_str(c.symbol());
+            }
+        }
+        assert!(row.starts_with("  "), "side indent: {row:?}");
+        assert!(row.contains("1 subagent"), "{row}");
+        let (hit, id) = app.subagent_strip_hit.first().expect("hit");
+        assert_eq!(hit.x, 0);
+        assert_eq!(hit.width, 80, "hit stays full width");
+        assert_eq!(id, "task-1");
     }
 
     #[test]

--- a/crates/tui/src/ui/todos.rs
+++ b/crates/tui/src/ui/todos.rs
@@ -93,12 +93,23 @@ pub fn item_line(item: &TodoItem, palette: &ThemePalette) -> Line<'static> {
 }
 
 fn item_line_width(item: &TodoItem, palette: &ThemePalette, width: u16) -> Line<'static> {
+    item_line_indented(item, palette, width, 0)
+}
+
+fn item_line_indented(
+    item: &TodoItem,
+    palette: &ThemePalette,
+    width: u16,
+    side: u16,
+) -> Line<'static> {
     let glyph = status_glyph(item.status);
     // Chevron + space is 2 columns; items use the same indent so the glyph
-    // column lines up with the header label (Grok tasks-pane rule).
-    let indent = "  ";
-    let prefix_cols = indent.width() + glyph.width() + 1;
-    let max = (width as usize).saturating_sub(prefix_cols).max(8);
+    // column lines up with the header label (Grok tasks-pane rule). Panel
+    // path adds `side` so the glyph sits on the shared body column.
+    let indent = format!("{}  ", " ".repeat(side as usize));
+    let prefix_cols = 2 + glyph.width() + 1;
+    let inner = (width as usize).saturating_sub((side as usize).saturating_mul(2));
+    let max = inner.saturating_sub(prefix_cols).max(8);
     let content = truncate_chars(first_line(&item.content), max);
     Line::from(vec![
         Span::raw(indent),
@@ -119,7 +130,7 @@ fn truncate_chars(s: &str, max: usize) -> String {
     format!("{kept}…")
 }
 
-fn header_line(app: &TuiApp, palette: &ThemePalette, width: u16) -> Line<'static> {
+fn header_line(app: &TuiApp, palette: &ThemePalette, width: u16, side: u16) -> Line<'static> {
     let total = app.todos.len();
     let done = terminal_count(&app.todos);
     let collapsed = is_collapsed(app);
@@ -148,19 +159,23 @@ fn header_line(app: &TuiApp, palette: &ThemePalette, width: u16) -> Line<'static
         count_style = count_style.add_modifier(Modifier::UNDERLINED);
     }
 
-    let mut spans = vec![
-        Span::styled(chevron, chevron_style),
-        Span::styled("Todos", label_style),
-        Span::styled(format!("  {counts}"), count_style),
-    ];
+    let mut spans = Vec::new();
+    if side > 0 {
+        spans.push(Span::raw(" ".repeat(side as usize)));
+    }
+    spans.push(Span::styled(chevron, chevron_style));
+    spans.push(Span::styled("Todos", label_style));
+    spans.push(Span::styled(format!("  {counts}"), count_style));
 
     let used: usize = spans.iter().map(|s| s.content.width()).sum();
     let bar_w = HEADER_BAR_CELLS;
+    // Text (and the right-aligned track) stay inside [side, width - side).
+    let inner_end = (width as usize).saturating_sub(side as usize);
     // "  " + bar
-    if total > 0 && width as usize >= used + 2 + bar_w as usize {
+    if total > 0 && inner_end >= used + 2 + bar_w as usize {
         let frac = done as f64 / total as f64;
         let bar = progress_bar_string(bar_w, frac);
-        let pad = (width as usize).saturating_sub(used + 1 + bar_w as usize);
+        let pad = inner_end.saturating_sub(used + 1 + bar_w as usize);
         spans.push(Span::raw(" ".repeat(pad.max(1))));
         let bar_color = if all_done {
             palette.success
@@ -175,7 +190,13 @@ fn header_line(app: &TuiApp, palette: &ThemePalette, width: u16) -> Line<'static
     Line::from(spans)
 }
 
-pub fn render_panel(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &ThemePalette) {
+pub fn render_panel(
+    frame: &mut Frame,
+    area: Rect,
+    app: &mut TuiApp,
+    palette: &ThemePalette,
+    side: u16,
+) {
     if area.height == 0 || app.todos.is_empty() {
         app.todos_hit.clear();
         return;
@@ -183,7 +204,7 @@ pub fn render_panel(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &T
     let collapsed = is_collapsed(app) || area.height == 1;
 
     let mut lines: Vec<Line> = Vec::new();
-    lines.push(header_line(app, palette, area.width));
+    lines.push(header_line(app, palette, area.width, side));
 
     if !collapsed {
         let mut budget = area.height.saturating_sub(1) as usize;
@@ -193,12 +214,13 @@ pub fn render_panel(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &T
         }
         let take = budget.min(MAX_ITEMS).min(app.todos.len());
         for item in app.todos.iter().take(take) {
-            lines.push(item_line_width(item, palette, area.width));
+            lines.push(item_line_indented(item, palette, area.width, side));
         }
         let hidden = app.todos.len().saturating_sub(take);
         if hidden > 0 {
+            let indent = format!("{}  ", " ".repeat(side as usize));
             lines.push(Line::from(Span::styled(
-                format!("  … +{hidden} more"),
+                format!("{indent}… +{hidden} more"),
                 Style::default().fg(palette.dim),
             )));
         }
@@ -228,11 +250,15 @@ mod tests {
     use whycodes_core::todo::{TodoItem, TodoStatus};
 
     fn paint(app: &mut TuiApp, w: u16, h: u16) -> String {
+        paint_with_side(app, w, h, 0)
+    }
+
+    fn paint_with_side(app: &mut TuiApp, w: u16, h: u16, side: u16) -> String {
         let palette = app.config.palette();
         let backend = TestBackend::new(w, h);
         let mut terminal = Terminal::new(backend).expect("term");
         terminal
-            .draw(|f| render_panel(f, f.area(), app, &palette))
+            .draw(|f| render_panel(f, f.area(), app, &palette, side))
             .expect("draw");
         let buf = terminal.backend().buffer().clone();
         let mut out = String::new();
@@ -372,5 +398,41 @@ mod tests {
         assert_eq!(status_glyph(TodoStatus::InProgress), "▶");
         assert_eq!(status_glyph(TodoStatus::Completed), "✓");
         assert_eq!(status_glyph(TodoStatus::Cancelled), "✗");
+    }
+
+    #[test]
+    fn panel_indents_text_by_side_and_keeps_item_line_unpadded() {
+        let mut app = TuiApp::new(TuiAppConfig::default());
+        app.replace_todos(
+            (0..10)
+                .map(|i| item(&i.to_string(), &format!("item {i}"), TodoStatus::Pending))
+                .collect(),
+        );
+        let text = paint_with_side(&mut app, 60, 12, 2);
+        let header = text.lines().next().expect("header");
+        assert!(header.starts_with("  ▾"), "side indent: {header:?}");
+        let item_row = text.lines().find(|l| l.contains("item 0")).expect("item 0");
+        assert!(
+            item_row.starts_with("    □"),
+            "side + 2 item indent: {item_row:?}"
+        );
+        let overflow = text
+            .lines()
+            .find(|l| l.contains("+2 more"))
+            .expect("overflow");
+        assert!(
+            overflow.starts_with("    …"),
+            "side + 2 overflow indent: {overflow:?}"
+        );
+        // Sidebar helper stays at the original two-space indent.
+        let sidebar = item_line(
+            &item("z", "sidebar row", TodoStatus::Pending),
+            &app.config.palette(),
+        );
+        let sidebar_s: String = sidebar.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            sidebar_s.starts_with("  □"),
+            "item_line must not take side: {sidebar_s:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- All body text now starts on the shared column `body.x + side_pad`: the sticky todo panel and subagent strip take a `side` indent (full-width backgrounds and hit targets unchanged), todo item rows sit at `side + 2`, and the header progress track is clamped to the same right margin.
- New `layout::PANEL_GAP` blank row between the sticky panels and the transcript, dropped on tiny bodies so the transcript keeps its 3-row minimum.
- The chat scrollbar now reserves `SCROLLBAR_GAP + SCROLLBAR_GUTTER`, so a blank column always sits between the text and the bar; the gap column is cleared every frame.
- Home keeps the plain `side_pad` since it never renders the sidebar rail (a phantom rail could previously flip the pad at ~72–84 col widths).

## Verification
- Empirical tmux capture (100x32) of a seeded session: todos header and chat text both start at column 3, todo items at column 5, one blank row under the panel, and a blank column left of the scrollbar (`PM  █`). Before: header at column 1 and the bar flush against text.
- `cargo test -p whycode-tui`: 651 lib + 5 integration tests pass, including new regression tests for panel/strip `side` indentation, the panel gap row, scrollbar gap column, and tiny-body gap suppression.
- `cargo fmt --all --check`, `cargo clippy -p whycode-tui --all-targets -- -D warnings`, panic/swallowed-error/dependency-boundary ratchets, and `cargo build -p whycode-cli` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)