### PR TITLE
perf(tui): paint home chrome before Agent/index hydrate (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Idle TUI, Linux x86_64, 2026-08-31 (method and machine in
 | 1 session PSS | **8.4 MB** |
 | 10 sessions PSS | **34.5 MB** (~2.9 MB each extra) |
 | `--version` | **1.5 ms** |
-| First frame (harness, in-proc) | **23 ms** |
+| First frame (harness, in-proc) | chrome-only paint, then hydrate ([#49](https://github.com/whycorporation/whycodes/issues/49)) |
 | Idle redraws (harness, 3 s) | **0.0 /s** |
 
 The TUI paints only when something changed: the idle target is **0

--- a/crates/cli/src/cmd/run.rs
+++ b/crates/cli/src/cmd/run.rs
@@ -48,11 +48,9 @@ pub(crate) async fn cmd_run(
     let model = resolve_model(cli, &config);
     let agent_name = resolve_agent(cli, &config);
     let project_dir = resolve_dir(cli);
-    config.load_command_files(&project_dir);
 
     // Interactive mode always starts (OpenCode-style). API key is optional until
     // the user actually sends a prompt that needs the LLM.
-    let mut api_key = get_api_key(&provider, &config).await.unwrap_or_default();
 
     // Full-screen TUI unless --plain / WHYCODES_PLAIN.
     // Hosts that capture stdout (IDE, some wrappers) report stdout_tty=false
@@ -76,6 +74,10 @@ pub(crate) async fn cmd_run(
     let max_turns = crate::ignore_max_turns_interactive(max_turns);
 
     if use_tui {
+        // Env/config only — OAuth store, slash-command files, and auth plugins
+        // hydrate after the first frame (`hydrate_tui_boot`).
+        let api_key = key_from_env_and_config(&provider, &config, |k| std::env::var(k).ok())
+            .unwrap_or_default();
         let update_rx = super::debug::spawn_update_check(cli, &config);
         let exit = whycodes_tui::run(whycodes_tui::TuiRunOptions {
             project_dir,
@@ -109,6 +111,9 @@ pub(crate) async fn cmd_run(
         })?;
         return super::debug::after_tui_exit(exit).await;
     }
+
+    config.load_command_files(&project_dir);
+    let mut api_key = get_api_key(&provider, &config).await.unwrap_or_default();
 
     let agent_info = {
         let mut info = agent_info_for(cli, &config);

--- a/crates/cli/src/cmd/serve.rs
+++ b/crates/cli/src/cmd/serve.rs
@@ -44,14 +44,15 @@ pub(crate) async fn cmd_connect(
     println!("{} session {}", "•".bold(), session_id.cyan());
 
     let project_dir = resolve_dir(cli);
-    let mut config = Config::load_layered(&project_dir)
+    let config = Config::load_layered(&project_dir)
         .or_else(|_| Config::load())
         .unwrap_or_default();
-    config.load_command_files(&project_dir);
     let provider = resolve_provider(cli, &config);
     let model = resolve_model(cli, &config);
     let agent_name = resolve_agent(cli, &config);
-    let api_key = get_api_key(&provider, &config).await.unwrap_or_default();
+    // Env/config only — OAuth store and slash-command files hydrate after paint.
+    let api_key =
+        key_from_env_and_config(&provider, &config, |k| std::env::var(k).ok()).unwrap_or_default();
 
     if !whycodes_tui::tui_available() {
         anyhow::bail!("connect needs a real TUI terminal (not --plain)");

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -107,6 +107,20 @@ fn runtime_for(cli: &Cli) -> std::io::Result<tokio::runtime::Runtime> {
     }
 }
 
+/// Interactive full-screen TUI: plugins / OAuth / slash files wait until
+/// after the first paint. `--plain` and structured `--format` stay eager.
+fn command_uses_interactive_tui(cli: &Cli) -> bool {
+    if cli.plain || std::env::var_os("WHYCODES_PLAIN").is_some() {
+        return false;
+    }
+    match &cli.command {
+        None => true,
+        Some(Commands::Run { format, .. }) => !format.is_structured(),
+        Some(Commands::Connect { .. }) => true,
+        _ => false,
+    }
+}
+
 fn command_needs_multi_thread(cli: &Cli) -> bool {
     match &cli.command {
         // Default bare invoke → interactive TUI / agent.
@@ -147,7 +161,12 @@ async fn async_main(cli: Cli) -> anyhow::Result<()> {
     // panic → data_dir/crash/. TUI keeps stderr quiet so the alternate screen
     // is not corrupted (use --debug or WHYCODES_LOG_FILE to capture human logs).
     init_logging(&cli);
-    load_auth_plugins(&cli);
+    // Auth plugins are OAuth client defs (disk + JSON). Interactive TUI
+    // loads them in `hydrate_tui_boot` after the first frame. Other commands
+    // still need them before dispatch (login, generate, connect health).
+    if !command_uses_interactive_tui(&cli) {
+        load_auth_plugins(&cli);
+    }
 
     // Determine which command to run; default to Run
     let result = match &cli.command {

--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -181,6 +181,33 @@ fn runtime_choice_per_command() {
 }
 
 #[test]
+fn interactive_tui_defers_auth_plugins() {
+    assert!(command_uses_interactive_tui(&cli(None)));
+    assert!(command_uses_interactive_tui(&cli(Some(Commands::Run {
+        prompt: None,
+        max_turns: None,
+        format: OutputFormat::Text,
+    }))));
+    assert!(command_uses_interactive_tui(&cli(Some(
+        Commands::Connect {
+            addr: "127.0.0.1:3030".into(),
+            session: None,
+        }
+    ))));
+    assert!(!command_uses_interactive_tui(&cli(Some(Commands::Run {
+        prompt: Some("hi".into()),
+        max_turns: None,
+        format: OutputFormat::Json,
+    }))));
+    let mut plain = cli(None);
+    plain.plain = true;
+    assert!(!command_uses_interactive_tui(&plain));
+    assert!(!command_uses_interactive_tui(&cli(Some(Commands::Auth {
+        cmd: AuthCmd::Status,
+    }))));
+}
+
+#[test]
 fn auto_update_only_interactive_text_sessions() {
     // Do not call `should_auto_update` for the "on" cases: GitHub Actions
     // sets `CI=true`, which is a real production opt-out.

--- a/crates/tui/src/app.rs
+++ b/crates/tui/src/app.rs
@@ -1656,11 +1656,7 @@ impl ModelSelectionState {
 /// would never appear here: merge in the suggested models for any provider
 /// with a credential in the token store.
 pub fn catalog_models(config: &whycodes_config::Config) -> Vec<(String, String)> {
-    let mut out: Vec<(String, String)> = config
-        .providers
-        .values()
-        .flat_map(|p| p.models.iter().map(move |m| (p.name.clone(), m.clone())))
-        .collect();
+    let mut out = catalog_models_from_config(config);
     if let Ok(dir) = whycodes_config::Config::data_dir() {
         let store = whycodes_auth::TokenStore::new(&dir);
         for name in whycodes_auth::oauth_providers() {
@@ -1673,6 +1669,18 @@ pub fn catalog_models(config: &whycodes_config::Config) -> Vec<(String, String)>
             }
         }
     }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Config-only catalog (no token-store I/O). First-frame chrome uses this.
+pub fn catalog_models_from_config(config: &whycodes_config::Config) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = config
+        .providers
+        .values()
+        .flat_map(|p| p.models.iter().map(move |m| (p.name.clone(), m.clone())))
+        .collect();
     out.sort();
     out.dedup();
     out
@@ -1996,8 +2004,14 @@ impl TuiApp {
     }
 
     pub fn new(config: crate::config::TuiAppConfig) -> Self {
-        config.theme.apply_syntax_theme();
+        // Syntect `SyntaxSet` load is deferred until after the first frame
+        // (`apply_syntax_theme` in hydrate). Home chrome does not highlight.
         Self::from_config(config)
+    }
+
+    /// Load syntect for the active theme. Call after the first paint.
+    pub fn apply_syntax_theme(&self) {
+        self.theme.apply_syntax_theme();
     }
 
     /// Same as [`Self::new`] but does **not** touch the process-wide syntax
@@ -2323,6 +2337,11 @@ impl TuiApp {
     /// Refresh `git_branch` from the working tree (cheap; call on start / idle).
     pub fn refresh_git_branch(&mut self) {
         self.git_branch = resolve_git_branch(&self.project_dir);
+    }
+
+    /// First-frame path: `.git/HEAD` only, never spawn `git`.
+    pub fn refresh_git_branch_fast(&mut self) {
+        self.git_branch = read_git_head_ref(&self.project_dir);
     }
 
     /// True if terminal cell `(col, row)` is inside the clickable cwd path.
@@ -3814,7 +3833,68 @@ pub fn chat_messages_from_session(
 const GIT_BRANCH_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(250);
 
 /// Resolve the current branch name for `dir`, if it is a git work tree.
+///
+/// First-frame path reads `.git/HEAD` (no process). `git rev-parse` is the
+/// fallback when HEAD is missing or a linked worktree needs the real gitdir.
 fn resolve_git_branch(dir: &std::path::Path) -> Option<String> {
+    if let Some(name) = read_git_head_ref(dir) {
+        return Some(name);
+    }
+    resolve_git_branch_process(dir)
+}
+
+/// Walk `dir` and parents for `.git/HEAD` or a `.git` gitdir file.
+pub(crate) fn read_git_head_ref(dir: &std::path::Path) -> Option<String> {
+    let mut cur = dir;
+    loop {
+        let git = cur.join(".git");
+        if git.is_file() {
+            let contents = std::fs::read_to_string(&git).ok()?;
+            let gitdir = contents
+                .lines()
+                .find_map(|l| l.strip_prefix("gitdir:"))?
+                .trim();
+            if gitdir.is_empty() {
+                return None;
+            }
+            let git_dir = {
+                let p = std::path::Path::new(gitdir);
+                if p.is_absolute() {
+                    p.to_path_buf()
+                } else {
+                    cur.join(p)
+                }
+            };
+            return parse_git_head_file(&git_dir.join("HEAD"));
+        }
+        if git.is_dir() {
+            return parse_git_head_file(&git.join("HEAD"));
+        }
+        cur = cur.parent()?;
+    }
+}
+
+fn parse_git_head_file(head: &std::path::Path) -> Option<String> {
+    let s = std::fs::read_to_string(head).ok()?;
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Some(r) = s.strip_prefix("ref: ") {
+        let name = r.strip_prefix("refs/heads/").unwrap_or(r);
+        if name.is_empty() {
+            return None;
+        }
+        return Some(name.to_string());
+    }
+    // Detached HEAD: object id. Short SHA matches `git rev-parse --short`.
+    if s.bytes().all(|b| b.is_ascii_hexdigit()) && s.len() >= 7 {
+        return Some(s[..7].to_string());
+    }
+    None
+}
+
+fn resolve_git_branch_process(dir: &std::path::Path) -> Option<String> {
     use std::process::Command;
 
     let out = git_output_timeout(
@@ -3887,6 +3967,41 @@ pub(crate) fn git_output_timeout(
                 return None;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod git_head_tests {
+    use super::*;
+
+    #[test]
+    fn read_git_head_ref_branch_and_detached() {
+        let dir = tempfile::tempdir().unwrap();
+        let git = dir.path().join(".git");
+        std::fs::create_dir(&git).unwrap();
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        assert_eq!(read_git_head_ref(dir.path()).as_deref(), Some("main"));
+
+        std::fs::write(git.join("HEAD"), "abcdef1234567890\n").unwrap();
+        let got = read_git_head_ref(dir.path()).expect("detached");
+        assert_eq!(got, "abcdef1");
+
+        let nested = dir.path().join("src");
+        std::fs::create_dir(&nested).unwrap();
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/feat/ttff\n").unwrap();
+        assert_eq!(read_git_head_ref(&nested).as_deref(), Some("feat/ttff"));
+    }
+
+    #[test]
+    fn read_git_head_ref_gitdir_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let real = dir.path().join("real.git");
+        std::fs::create_dir(&real).unwrap();
+        std::fs::write(real.join("HEAD"), "ref: refs/heads/worktree\n").unwrap();
+        let work = dir.path().join("work");
+        std::fs::create_dir(&work).unwrap();
+        std::fs::write(work.join(".git"), format!("gitdir: {}\n", real.display())).unwrap();
+        assert_eq!(read_git_head_ref(&work).as_deref(), Some("worktree"));
     }
 }
 

--- a/crates/tui/src/run/mod.rs
+++ b/crates/tui/src/run/mod.rs
@@ -209,7 +209,7 @@ pub enum TuiExit {
 /// Sentinel for `TuiRunOptions::resume_session_id`: most recently updated session.
 pub const RESUME_LATEST: &str = "__latest__";
 
-/// Everything `run` needs before it touches the terminal.
+/// Hydrated runtime (index, agent, session). Built *after* the first paint.
 struct TuiBoot {
     app: TuiApp,
     config: Config,
@@ -223,6 +223,8 @@ struct TuiBoot {
     question_rx: mpsc::UnboundedReceiver<QuestionRequest>,
     session_claims: whycodes_core::FileClaimRegistry,
     missing_key: bool,
+    /// Resolved after hydrate (env/config plus OAuth store). Chrome uses `opts.api_key`.
+    api_key: String,
 }
 
 fn apply_resume(
@@ -297,14 +299,11 @@ async fn apply_remote_hydrate(
     );
 }
 
-async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
+/// Home chrome only — no index, agent, plugins, memory, syntect, or SQLite.
+/// First paint uses this so TTFF is not blocked by hydrate.
+fn prepare_tui_chrome(opts: &TuiRunOptions) -> (TuiApp, bool) {
     let tui_cfg = TuiAppConfig::from_core_config(&opts.config.tui);
     let mut app = TuiApp::new(tui_cfg);
-
-    let file_index = whycodes_index::WorkspaceIndex::start(
-        whycodes_index::WorkspaceIndex::project_roots(&opts.project_dir),
-    );
-    app.set_file_index(file_index.clone());
 
     app.provider_name = opts.provider.clone();
     app.model_name = opts.model.clone();
@@ -320,7 +319,8 @@ async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
         .file_name()
         .map(|s| s.to_string_lossy().to_string())
         .unwrap_or_else(|| whycodes_core::display_path(&app.project_dir));
-    app.refresh_git_branch();
+    // `.git/HEAD` only — never spawn `git` on the first-frame path.
+    app.refresh_git_branch_fast();
     app.apply_context_window(
         &opts.provider,
         &opts.model,
@@ -328,6 +328,75 @@ async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
             .configured_context_window(&opts.provider, &opts.model),
         opts.config.session.max_context_tokens as u64,
     );
+
+    // Custom slash commands are loaded in hydrate (`load_command_files`).
+    app.primary_agents = opts
+        .config
+        .agents
+        .iter()
+        .filter(|a| a.mode == AgentMode::Primary || a.mode == AgentMode::All)
+        .map(|a| a.name.clone())
+        .collect();
+    if app.primary_agents.is_empty() {
+        app.primary_agents = vec!["build".into(), "plan".into(), "ask".into()];
+    }
+    if let Some(idx) = app
+        .primary_agents
+        .iter()
+        .position(|n| n == &opts.agent_name)
+    {
+        app.agent_cycle_idx = idx;
+    }
+    // Config-only catalog: token-store I/O waits until hydrate.
+    app.model_selection.models = crate::app::catalog_models_from_config(&opts.config);
+    app.model_selection.selected = app
+        .model_selection
+        .models
+        .iter()
+        .position(|(p, m)| p == &opts.provider && m == &opts.model)
+        .unwrap_or(0);
+
+    let missing_key = opts.api_key.is_empty()
+        && whycodes_llm::provider_requires_api_key(&opts.provider, Some(&opts.config));
+    app.status_message = if missing_key {
+        format!(
+            "agent={}  {}/{}  — no API key · /connect  /help",
+            opts.agent_name, opts.provider, opts.model
+        )
+    } else {
+        format!(
+            "agent={}  {}/{}  — Tab focus  Ctrl+T agent  Esc cancel  /help",
+            opts.agent_name, opts.provider, opts.model
+        )
+    };
+
+    (app, missing_key)
+}
+
+/// Auth plugins from the same dirs the CLI uses (`$CONFIG/plugins`, project).
+fn load_tui_auth_plugins(project_dir: &std::path::Path) {
+    let mut dirs = Vec::new();
+    if let Ok(p) = Config::default_path()
+        && let Some(parent) = p.parent()
+    {
+        dirs.push(parent.join("plugins"));
+    }
+    dirs.push(whycodes_core::project_dir(project_dir).join("plugins"));
+    let n = whycodes_auth::plugin::load_from_dirs(&dirs);
+    if n > 0 {
+        tracing::info!(count = n, "loaded auth plugins");
+    }
+}
+
+/// Everything that must not block the first `record_draw`.
+async fn hydrate_tui_boot(opts: &TuiRunOptions, mut app: TuiApp) -> TuiBoot {
+    load_tui_auth_plugins(&opts.project_dir);
+    app.apply_syntax_theme();
+
+    let file_index = whycodes_index::WorkspaceIndex::start(
+        whycodes_index::WorkspaceIndex::project_roots(&opts.project_dir),
+    );
+    app.set_file_index(file_index.clone());
 
     let mut config = opts.config.clone();
     config.load_command_files(&opts.project_dir);
@@ -356,8 +425,19 @@ async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
         .position(|(p, m)| p == &opts.provider && m == &opts.model)
         .unwrap_or(0);
 
-    let missing_key = opts.api_key.is_empty()
-        && whycodes_llm::provider_requires_api_key(&opts.provider, Some(&opts.config));
+    let mut api_key = opts.api_key.clone();
+    if api_key.is_empty() {
+        if let Ok(dir) = Config::data_dir()
+            && let Some(k) = whycodes_auth::providers::access_token(&opts.provider, &dir).await
+        {
+            api_key = k;
+            whycodes_llm::oauth_refresh::register(&opts.provider, dir);
+        }
+    } else {
+        whycodes_llm::oauth_refresh::unregister(&opts.provider);
+    }
+    let missing_key = api_key.is_empty()
+        && whycodes_llm::provider_requires_api_key(&opts.provider, Some(&config));
     app.status_message = if missing_key {
         format!(
             "agent={}  {}/{}  — no API key · /connect  /help",
@@ -369,6 +449,9 @@ async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
             opts.agent_name, opts.provider, opts.model
         )
     };
+
+    // Process fallback if `.git/HEAD` was missing (linked worktree, etc.).
+    app.refresh_git_branch();
 
     let agent_info = config
         .get_agent(&opts.agent_name)
@@ -430,9 +513,7 @@ async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
     let mut session = Session::new(opts.project_dir.clone(), system_prompt.clone());
     app.session_title = session.title.clone();
     app.session_id = session.id.clone();
-    if app.session_list.sessions.is_empty() {
-        app.session_list.sessions = load_session_entries();
-    }
+    app.session_list.sessions = load_session_entries();
     let history = SessionHistory::new();
 
     if let Some(ref want) = opts.resume_session_id {
@@ -462,7 +543,14 @@ async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
         question_rx,
         session_claims,
         missing_key,
+        api_key,
     }
+}
+
+#[cfg(test)]
+async fn prepare_tui_boot(opts: &TuiRunOptions) -> TuiBoot {
+    let (app, _) = prepare_tui_chrome(opts);
+    hydrate_tui_boot(opts, app).await
 }
 
 /// True when a full-screen TUI can attach to a real terminal.
@@ -609,21 +697,9 @@ pub async fn run(opts: TuiRunOptions) -> anyhow::Result<TuiExit> {
     // Wall clock for the Cline-style exit summary (process open → quit).
     let session_started = Instant::now();
 
-    let boot = prepare_tui_boot(&opts).await;
-    let mut app = boot.app;
-    let mut config = boot.config;
-    let file_index = boot.file_index;
-    let mut agent = boot.agent;
-    let session = boot.session;
-    let history = boot.history;
-    let perm_prompter = boot.perm_prompter;
-    let question_prompter = boot.question_prompter;
-    let perm_rx = boot.perm_rx;
-    let question_rx = boot.question_rx;
-    let session_claims = boot.session_claims;
-    let missing_key = boot.missing_key;
+    // Chrome only — first `record_draw` must not wait on Agent / index / plugins.
+    let (mut app, _) = prepare_tui_chrome(&opts);
     let remote = opts.remote.clone();
-
     let mut provider = opts.provider.clone();
     let mut model = opts.model.clone();
     let mut api_key = opts.api_key.clone();
@@ -753,6 +829,93 @@ pub async fn run(opts: TuiRunOptions) -> anyhow::Result<TuiExit> {
         })),
     );
 
+    // Inert unless WHYCODES_BENCH is set; see crate::bench.
+    let bench = crate::bench::config_from_env();
+
+    // Paint home chrome *before* Agent / index / plugins / SQLite / syntect.
+    // Clock is `mark_process_start` → this `record_draw`.
+    match terminal.draw(|f| render::render(f, &mut app)) {
+        Ok(completed) => {
+            crate::bench::record_draw();
+            whycodes_core::logging::emit(
+                "whycodes_tui",
+                "info",
+                "tui.first_frame",
+                Some(serde_json::json!({
+                    "w": completed.area.width,
+                    "h": completed.area.height,
+                })),
+            );
+        }
+        Err(e) => {
+            whycodes_core::logging::emit(
+                "whycodes_tui",
+                "error",
+                "tui.draw_failed",
+                Some(serde_json::json!({ "error": e.to_string() })),
+            );
+            return Err(e.into());
+        }
+    }
+    app.needs_redraw = false;
+
+    // `--idle-ms 0` (WHYCODES_BENCH_DURATION_MS=0): first paint is the
+    // measurement. Do not pay Agent / index / plugins / SQLite on the way out.
+    if let Some(ref bench) = bench
+        && crate::bench::should_stop(bench)
+    {
+        if let Err(e) = disable_raw_mode() {
+            tracing::debug!(error = %e, "bench restore disable_raw_mode");
+        }
+        if keyboard_enhanced
+            && let Err(e) = execute!(terminal.backend_mut(), PopKeyboardEnhancementFlags)
+        {
+            tracing::debug!(error = %e, "bench restore pop keyboard flags");
+        }
+        if let Err(e) = execute!(
+            terminal.backend_mut(),
+            DisableBracketedPaste,
+            DisableMouseCapture,
+            LeaveAlternateScreen,
+            SetCursorStyle::DefaultUserShape
+        ) {
+            tracing::debug!(error = %e, "bench restore leave alt-screen");
+        }
+        if let Err(e) = terminal.show_cursor() {
+            tracing::debug!(error = %e, "bench restore show_cursor");
+        }
+        whycodes_core::logging::clear_panic_cleanup();
+        crate::bench::write_results(bench);
+        whycodes_core::logging::emit(
+            "whycodes_tui",
+            "info",
+            "tui.stopped",
+            Some(serde_json::json!({
+                "ok": true,
+                "reason": "bench_first_frame",
+            })),
+        );
+        return Ok(TuiExit::Quit);
+    }
+
+    // Heavy work after the first frame is on screen.
+    let boot = hydrate_tui_boot(&opts, app).await;
+    let mut app = boot.app;
+    let mut config = boot.config;
+    let file_index = boot.file_index;
+    let mut agent = boot.agent;
+    let session = boot.session;
+    let history = boot.history;
+    let perm_prompter = boot.perm_prompter;
+    let question_prompter = boot.question_prompter;
+    let perm_rx = boot.perm_rx;
+    let question_rx = boot.question_rx;
+    let session_claims = boot.session_claims;
+    let missing_key = boot.missing_key;
+    if !boot.api_key.is_empty() {
+        api_key = boot.api_key;
+    }
+
     let (event_tx, event_rx) = mpsc::unbounded_channel::<TurnEvent>();
     let (done_tx, done_rx) = mpsc::unbounded_channel::<TurnOutcome>();
     // Async session titles (small-model refine) — never blocks agent_busy.
@@ -805,10 +968,11 @@ pub async fn run(opts: TuiRunOptions) -> anyhow::Result<TuiExit> {
     let mut update_rx = opts.update_rx;
 
     apply_boot_prompt(&mut app, missing_key, opts.initial_prompt.clone());
+    // Recents / resume landed after the chrome frame — redraw once.
+    app.mark_dirty();
 
-    // Inert unless WHYCODES_BENCH is set; see crate::bench.
-    let bench = crate::bench::config_from_env();
-
+    // True until the post-hydrate paint so `just_first` still loads MCP /
+    // auto-index (those must not run on the chrome-only frame).
     let mut first_frame = true;
     // Paste / resize / focus can echo glyphs onto the PTY outside ratatui's
     // diff. Clear the terminal on the next paint so leftover text cannot sit
@@ -892,15 +1056,8 @@ pub async fn run(opts: TuiRunOptions) -> anyhow::Result<TuiExit> {
                 let just_first = first_frame;
                 if first_frame {
                     first_frame = false;
-                    whycodes_core::logging::emit(
-                        "whycodes_tui",
-                        "info",
-                        "tui.first_frame",
-                        Some(serde_json::json!({
-                            "w": completed.area.width,
-                            "h": completed.area.height,
-                        })),
-                    );
+                    // Chrome already logged `tui.first_frame` before hydrate.
+                    // MCP / auto-index run here so they stay off the TTFF clock.
                 }
                 // Cell snapshot is only for mouse text selection → clipboard.
                 // Skip the ~4k String allocs/frame when nothing is selected.

--- a/crates/tui/src/run/tests.rs
+++ b/crates/tui/src/run/tests.rs
@@ -2991,6 +2991,45 @@ async fn prepare_tui_boot_sets_chrome_and_defaults() {
 }
 
 #[test]
+fn prepare_tui_chrome_skips_index_and_session_list() {
+    isolate_home();
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("README.md"), "hi").unwrap();
+    let git = dir.path().join(".git");
+    std::fs::create_dir(&git).unwrap();
+    std::fs::write(git.join("HEAD"), "ref: refs/heads/ttff\n").unwrap();
+    let mut opts = boot_opts(dir.path(), "sk-test");
+    opts.agent_name = "plan".into();
+    let mut plan = dummy_info("plan");
+    plan.mode = AgentMode::All;
+    opts.config.agents.push(plan);
+
+    let (app, missing_key) = prepare_tui_chrome(&opts);
+    assert!(!missing_key);
+    assert_eq!(app.provider_name, "acme");
+    assert_eq!(app.model_name, "m1");
+    assert_eq!(app.agent_name, "plan");
+    assert_eq!(app.git_branch.as_deref(), Some("ttff"));
+    assert!(app.session_list.sessions.is_empty());
+    assert!(app.file_suggest.scan_status().is_none());
+    assert!(app.status_message.contains("Tab focus"));
+}
+
+#[tokio::test]
+async fn hydrate_tui_boot_loads_recents_after_chrome() {
+    isolate_home();
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("README.md"), "hi").unwrap();
+    let opts = boot_opts(dir.path(), "sk-test");
+    let (app, _missing) = prepare_tui_chrome(&opts);
+    assert!(app.session_list.sessions.is_empty());
+    let boot = hydrate_tui_boot(&opts, app).await;
+    assert!(!boot.missing_key);
+    assert_eq!(boot.api_key, "sk-test");
+    assert!(boot.app.file_suggest.scan_status().is_some());
+}
+
+#[test]
 fn apply_resume_found_missing_and_latest() {
     let (_home_lock, _home) = isolate_home_fresh();
     let dir = tempfile::tempdir().unwrap();

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -245,7 +245,7 @@ process than the 08-26 row. Still a lower bound (idle, no agent turn).
 
 | Source | First frame | Idle draws/s | Notes |
 |---|---|---|---|
-| Harness `--idle-ms 0` (12 runs) | **22.6 ms** median | 0.0/s | was 18.4 ms |
+| Harness `--idle-ms 0` (12 runs) | **22.6 ms** median | 0.0/s | was 18.4 ms; #49 paints chrome before hydrate |
 | Harness `--idle-ms 3000` (10 runs) | **27.8 ms** median | **0.0/s** | still zero idle paints |
 
 Spawn-to-exit at `--idle-ms 0` is **29.9 ms**. Idle redraws remain the

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -144,6 +144,30 @@ Only bump a budget in the **same commit**, and say why. If the count is *below* 
 
 ## Log
 
+### 2026-09-01 — First frame is chrome-only; hydrate after `record_draw` (#49)
+
+**Symptom:** In-proc TTFF (`mark_process_start` → first `record_draw`) sat at
+~23 ms. Home chrome waited on `Agent::new`, workspace index, plugins,
+project memory, slash-command files, OAuth `auth.json`, syntect, and
+`git rev-parse` (250 ms timeout).
+
+**Root cause:** `prepare_tui_boot` ran the full runtime before `run()`
+touched the terminal. `--idle-ms 0` still paid that cost on the way out.
+`just_first` MCP must not run on the chrome-only frame.
+
+**Fix:** `prepare_tui_chrome` + first `record_draw`, then `hydrate_tui_boot`.
+`--idle-ms 0` restores the terminal and writes bench JSON without hydrate.
+MCP / auto-index stay on the post-hydrate `just_first` paint. Branch on
+the first frame is `.git/HEAD` only (`refresh_git_branch_fast`). CLI TUI
+path skips `load_auth_plugins`, OAuth store, and `load_command_files`
+until hydrate.
+
+**Prevention:** Do not add I/O to `prepare_tui_chrome` / `TuiApp::new`.
+Keep syntect in `apply_syntax_theme` after the first paint. Bench
+`should_stop` after chrome paint must not call hydrate.
+
+---
+
 ### 2026-09-01 — Apple Terminal.app RGB + DIM leak to white / build-green
 
 **Symptom:** On macOS Terminal.app, modal chrome (help, pickers, question)


### PR DESCRIPTION
Fixes https://github.com/whycorporation/whycodes/issues/49

First-frame clock is `mark_process_start` → first `record_draw`. Home chrome no longer waits on `Agent::new`, workspace index, plugins, project memory, slash-command files, OAuth `auth.json`, syntect, or `git rev-parse`.

- `prepare_tui_chrome` paints 80×24 home (status, `.git/HEAD` branch) then `record_draw`
- `hydrate_tui_boot` runs after that frame (index, plugins, memory, syntect, SQLite, Agent)
- `--idle-ms 0` restores the terminal and writes bench JSON without hydrate
- MCP / auto-index stay on the post-hydrate `just_first` paint
- CLI TUI path skips `load_auth_plugins`, OAuth store, and `load_command_files` until hydrate

Idle redraws remain 0.0/s. Re-measure with `python scripts/bench_first_frame.py --idle-ms 0`.