### PR TITLE
fix(tui): clip chat scroll paint to the buffer

### DIFF
--- a/crates/tui/src/ui/chat.rs
+++ b/crates/tui/src/ui/chat.rs
@@ -56,18 +56,18 @@ pub fn message_row_layout(app: &TuiApp, width: u16) -> (Vec<usize>, usize) {
         // Key is (width, closed) — not global `is_busy()`. A new turn must
         // not evict every finished bubble's height (that froze scroll).
         let closed = message_is_closed(app, i);
-        if let Some((w, c, h)) = msg.layout_cache
-            && w == width
-            && c == closed
-        {
-            total += h;
-            continue;
-        }
         if let Some((w, c, ref lines)) = msg.line_cache
             && w == width
             && c == closed
         {
             total += lines.len();
+            continue;
+        }
+        if let Some((w, c, h)) = msg.layout_cache
+            && w == width
+            && c == closed
+        {
+            total += h;
             continue;
         }
         total += render_message(msg, app, &palette, i, width, None, false).len();
@@ -83,17 +83,19 @@ pub fn message_row_layout_mut(app: &mut TuiApp, width: u16) -> (Vec<usize>, usiz
     for i in 0..n {
         starts.push(total);
         let closed = message_is_closed(app, i);
-        let h = if let Some((w, c, h)) = app.messages[i].layout_cache
-            && w == width
-            && c == closed
-        {
-            h
-        } else if let Some((w, c, ref lines)) = app.messages[i].line_cache
+        let h = if let Some((w, c, ref lines)) = app.messages[i].line_cache
             && w == width
             && c == closed
         {
             let h = lines.len();
-            app.messages[i].layout_cache = Some((width, closed, h));
+            if app.messages[i].layout_cache != Some((width, closed, h)) {
+                app.messages[i].layout_cache = Some((width, closed, h));
+            }
+            h
+        } else if let Some((w, c, h)) = app.messages[i].layout_cache
+            && w == width
+            && c == closed
+        {
             h
         } else if !closed {
             // Live bubble: prefix (thinking/tools) is small; markdown lives in
@@ -323,8 +325,13 @@ fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &The
         let selected =
             app.selected_msg == Some(i) && app.focus == crate::app::FocusPane::Scrollback;
         let closed = message_is_closed(app, i);
+        // Cap to the laid-out slot. A stale `layout_cache` can under-count
+        // height; re-render then paints extra rows and `set_stringn` panics
+        // once `y` walks off the chat rect (issue #72, recovered overlay).
+        let msg_end = starts.get(i + 1).copied().unwrap_or(total);
+        let laid_out_h = msg_end.saturating_sub(msg_start);
         let slice_from = view_start.saturating_sub(msg_start);
-        let slice_to_excl = view_end.saturating_sub(msg_start);
+        let slice_to_excl = view_end.saturating_sub(msg_start).min(laid_out_h);
 
         // Cheap Arc clone so we can paint by reference without holding
         // `app.messages` borrowed across a possible cache fill.
@@ -340,6 +347,9 @@ fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &The
             });
 
         if let Some(ref lines) = cached {
+            if lines.len() != laid_out_h {
+                app.messages[i].layout_cache = Some((content_width, closed, lines.len()));
+            }
             y = paint_message_slice(
                 buf,
                 y,
@@ -388,8 +398,10 @@ fn render_session(frame: &mut Frame, area: Rect, app: &mut TuiApp, palette: &The
     }
 
     // If layout undershot (stale height), blank any leftover rows so scroll
-    // cannot leave ghost glyphs from the previous frame.
-    let end_y = area.y.saturating_add(area.height);
+    // cannot leave ghost glyphs from the previous frame. Stay inside the
+    // chat rect — extra rows from a stale cache must not walk into the
+    // prompt or off the buffer (`set_stringn` panics there).
+    let end_y = area.y.saturating_add(area.height).min(buf.area().bottom());
     while y < end_y {
         paint_chat_row(buf, y, &row, None, false);
         y = y.saturating_add(1);
@@ -533,7 +545,11 @@ fn paint_concat_slices(
     } else {
         None
     };
+    let clip_y = buf.area().bottom();
     for abs in from..to {
+        if y >= clip_y {
+            break;
+        }
         let line = if abs < a.len() {
             &a[abs]
         } else {
@@ -558,8 +574,19 @@ fn paint_chat_row(
     if row.width == 0 {
         return;
     }
-    let x0 = row.x;
-    let end = x0.saturating_add(row.width);
+    let area = buf.area();
+    // `set_stringn` panics on coordinates outside the buffer (issue #72).
+    if y < area.y || y >= area.bottom() {
+        return;
+    }
+    let x0 = row.x.max(area.x);
+    let end = x0
+        .saturating_add(row.width)
+        .min(area.right())
+        .min(row.x.saturating_add(row.width));
+    if x0 >= end {
+        return;
+    }
     let clear = Style::default().fg(row.bg).bg(row.bg);
     let mut x = x0;
     let mut band_bg: Option<Color> = None;

--- a/crates/tui/src/ui/chat_scroll_tests.rs
+++ b/crates/tui/src/ui/chat_scroll_tests.rs
@@ -922,6 +922,35 @@ fn selected_scrollback_paint_reuses_line_cache() {
 }
 
 #[test]
+fn stale_layout_cache_scroll_paint_does_not_panic() {
+    // Issue #72: a layout_cache that under-counts a closed bubble made the
+    // next scroll frame re-render extra rows and `set_stringn` panic once
+    // `y` walked off the buffer. Recovered as the "rendering error" overlay.
+    let mut app = TuiApp::new(cfg());
+    fill_overflowing_chat(&mut app, 16);
+    paint_session(&mut app, 40, 10);
+    assert!(
+        app.messages
+            .iter()
+            .all(|m| m.layout_cache.is_some() && m.line_cache.is_some()),
+        "first paint must fill caches"
+    );
+
+    // Under-count every closed bubble so starts[] no longer match line counts.
+    for msg in &mut app.messages {
+        if let Some((w, c, h)) = msg.layout_cache {
+            msg.layout_cache = Some((w, c, h.saturating_sub(3).max(1)));
+        }
+        msg.line_cache = None;
+    }
+
+    app.scroll_rows(chat_wheel_step(&app));
+    paint_session(&mut app, 40, 10);
+    app.scroll_rows(-chat_wheel_step(&app));
+    paint_session(&mut app, 40, 10);
+}
+
+#[test]
 fn wheel_step_scales_with_viewport() {
     let mut app = TuiApp::new(cfg());
     app.chat_viewport_rows = 6;

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -144,6 +144,27 @@ Only bump a budget in the **same commit**, and say why. If the count is *below* 
 
 ## Log
 
+### 2026-09-07 — Chat scroll paint panics (`index outside of buffer`)
+
+**Symptom:** Wheel / trackpad scroll in a session paints the recovered
+overlay (`rendering error recovered`) instead of moving the transcript.
+Issue #72.
+
+**Root cause:** `Buffer::set_stringn` panics on coordinates outside the
+buffer. Chat layout can under-count a closed bubble (`layout_cache`
+stale vs real `line_cache` / re-render). The next scroll frame then
+paints extra rows and `y` walks off the chat rect into the prompt or
+past `area.bottom()`.
+
+**Fix:** Prefer `line_cache.len()` over a conflicting `layout_cache`.
+Cap each message slice to its laid-out slot. Clip `paint_chat_row` /
+`paint_concat_slices` to `buf.area()`. Refresh a mismatched height on
+paint so the next frame is consistent.
+
+**Prevention:** Never call `set_stringn` without a buffer-bounds check.
+Do not trust `layout_cache` when `line_cache` is present. Regression:
+`stale_layout_cache_scroll_paint_does_not_panic`.
+
 ### 2026-09-07 — Serve takeover test spawned a just-written `.sh` (ETXTBSY / noexec)
 
 **Symptom:** CI `Test (linux)` failed


### PR DESCRIPTION
## Summary
Wheel / trackpad scroll in a session could paint the recovered overlay (`rendering error recovered`) instead of moving the transcript ([#72](https://github.com/whycorporation/whycodes/issues/72)).

`Buffer::set_stringn` panics on coordinates outside the buffer. Chat layout could under-count a closed bubble (`layout_cache` stale vs real `line_cache` / re-render). The next scroll frame then painted extra rows and `y` walked off the chat rect.

## Changes
- Prefer `line_cache.len()` over a conflicting `layout_cache`
- Cap each message slice to its laid-out slot
- Clip `paint_chat_row` / `paint_concat_slices` to `buf.area()`
- Refresh a mismatched height on paint so the next frame is consistent
- Regression: `stale_layout_cache_scroll_paint_does_not_panic`

## Test plan
- [x] `cargo test -p whycodes-tui --lib scroll --features whycodes-storage/bundled`
- [x] `cargo fmt --all --check`
- [x] budget scripts

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)