### PR TITLE
feat(tools): tag read/grep lines so edit can name a span

### DIFF
--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -11,6 +11,7 @@ description = "Cross-session semantic / auto memory for whycodes"
 default = []
 # MiniLM ONNX runtime (tract + tokenizers). Off by default for lean Boot/RSS.
 onnx = ["dep:tract-onnx", "dep:tokenizers"]
+bundled-sqlite = ["whycodes-storage/bundled"]
 
 [dependencies]
 whycodes-core = { path = "../core" }

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -9,6 +9,7 @@ repository.workspace = true
 [features]
 default = []
 onnx = ["whycodes-memory/onnx"]
+bundled-sqlite = ["whycodes-memory/bundled-sqlite"]
 
 [dependencies]
 whycodes-core = { path = "../core" }

--- a/crates/tools/src/file/edit.rs
+++ b/crates/tools/src/file/edit.rs
@@ -24,9 +24,10 @@ impl Tool for EditTool {
     }
 
     fn description(&self) -> &str {
-        "Make targeted edits to a file by finding and replacing exact text. \
-         If the exact `old_string` is missing, a unique whitespace-tolerant \
-         match (indent / extra spaces only — not typos) is applied."
+        "Make targeted edits to a file. Prefer `from`/`to`/`insert_after` \
+         content tags from `read`/`grep` (`N tag|text`). `old_string` is \
+         the fallback: exact match, then unique whitespace-tolerant match \
+         (indent / extra spaces only — not typos)."
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -39,18 +40,30 @@ impl Tool for EditTool {
                 },
                 "old_string": {
                     "type": "string",
-                    "description": "The exact text to find"
+                    "description": "Exact text to find. Required unless from/to/insert_after is set."
                 },
                 "new_string": {
                     "type": "string",
-                    "description": "The replacement text"
+                    "description": "The replacement or inserted text"
+                },
+                "from": {
+                    "type": "string",
+                    "description": "Content tag of the first line to replace (inclusive)"
+                },
+                "to": {
+                    "type": "string",
+                    "description": "Content tag of the last line to replace (inclusive). Omit for a single line."
+                },
+                "insert_after": {
+                    "type": "string",
+                    "description": "Content tag after which to insert new_string (no deletion)"
                 },
                 "replace_all": {
                     "type": "boolean",
-                    "description": "Replace all occurrences (default: false)"
+                    "description": "Replace all occurrences of old_string (default: false)"
                 }
             },
-            "required": ["path", "old_string", "new_string"]
+            "required": ["path", "new_string"]
         })
     }
 
@@ -64,6 +77,9 @@ impl Tool for EditTool {
             let old_string = args["old_string"].as_str().unwrap_or("").to_string();
             let new_string = args["new_string"].as_str().unwrap_or("").to_string();
             let replace_all = args["replace_all"].as_bool().unwrap_or(false);
+            let from = args["from"].as_str().map(str::to_string);
+            let to = args["to"].as_str().map(str::to_string);
+            let insert_after = args["insert_after"].as_str().map(str::to_string);
 
             let full_path = if std::path::Path::new(&path_str).is_absolute() {
                 path_str
@@ -84,7 +100,16 @@ impl Tool for EditTool {
 
             let shown = display_path(std::path::Path::new(&full_path), &ctx.working_dir);
             crate::blocking::tool(move || {
-                Self::run(full_path, shown, old_string, new_string, replace_all)
+                Self::run(
+                    full_path,
+                    shown,
+                    old_string,
+                    new_string,
+                    replace_all,
+                    from,
+                    to,
+                    insert_after,
+                )
             })
             .await
         })
@@ -92,55 +117,73 @@ impl Tool for EditTool {
 }
 
 impl EditTool {
+    #[allow(clippy::too_many_arguments)]
     fn run(
         full_path: String,
         shown: String,
         old_string: String,
         new_string: String,
         replace_all: bool,
+        from: Option<String>,
+        to: Option<String>,
+        insert_after: Option<String>,
     ) -> ToolResult {
         match std::fs::read_to_string(&full_path) {
-            Ok(original) => match locate_spans(&original, &old_string, replace_all) {
-                Locate::None => ToolResult {
-                    tool_call_id: String::new(),
-                    content: "Could not find the specified text in the file.".to_string(),
-                    is_error: true,
-                },
-                Locate::Ambiguous(count) => ToolResult {
-                    tool_call_id: String::new(),
-                    content: format!(
-                        "Found {count} occurrences of the search text. Use replace_all=true or provide a more specific match."
-                    ),
-                    is_error: true,
-                },
-                Locate::Hits(spans) => {
-                    let matched = original[spans[0].0..spans[0].1].to_string();
-                    let count = spans.len();
-                    let modified = apply_spans(&original, &spans, &new_string);
-                    let start = first_line_number(&original, &matched);
-                    match crate::file::atomic::write_atomic(
-                        std::path::Path::new(&full_path),
-                        &modified,
+            Ok(original) => {
+                let tagged = from.is_some() || insert_after.is_some();
+                if tagged {
+                    match apply_tagged(
+                        &original,
+                        from.as_deref(),
+                        to.as_deref(),
+                        insert_after.as_deref(),
+                        &new_string,
                     ) {
-                        Ok(()) => ToolResult {
+                        Ok((matched, modified, start)) => write_edit(
+                            &full_path,
+                            &shown,
+                            &matched,
+                            &new_string,
+                            1,
+                            start,
+                            &modified,
+                        ),
+                        Err(msg) => ToolResult {
                             tool_call_id: String::new(),
-                            content: format_edit_preview_at(
+                            content: msg,
+                            is_error: true,
+                        },
+                    }
+                } else {
+                    match locate_spans(&original, &old_string, replace_all) {
+                        Locate::None => ToolResult {
+                            tool_call_id: String::new(),
+                            content: miss_with_snippet(&original, &old_string),
+                            is_error: true,
+                        },
+                        Locate::Ambiguous(count) => ToolResult {
+                            tool_call_id: String::new(),
+                            content: ambiguous_with_tags(&original, &old_string, count),
+                            is_error: true,
+                        },
+                        Locate::Hits(spans) => {
+                            let matched = original[spans[0].0..spans[0].1].to_string();
+                            let count = spans.len();
+                            let modified = apply_spans(&original, &spans, &new_string);
+                            let start = first_line_number(&original, &matched);
+                            write_edit(
+                                &full_path,
                                 &shown,
                                 &matched,
                                 &new_string,
                                 count,
                                 start,
-                            ),
-                            is_error: false,
-                        },
-                        Err(e) => ToolResult {
-                            tool_call_id: String::new(),
-                            content: format!("Error writing file: {e}"),
-                            is_error: true,
-                        },
+                                &modified,
+                            )
+                        }
                     }
                 }
-            },
+            }
             Err(e) => ToolResult {
                 tool_call_id: String::new(),
                 content: format!("Error reading file: {e}"),
@@ -148,6 +191,149 @@ impl EditTool {
             },
         }
     }
+}
+
+fn write_edit(
+    full_path: &str,
+    shown: &str,
+    matched: &str,
+    new_string: &str,
+    count: usize,
+    start: Option<usize>,
+    modified: &str,
+) -> ToolResult {
+    match crate::file::atomic::write_atomic(std::path::Path::new(full_path), modified) {
+        Ok(()) => ToolResult {
+            tool_call_id: String::new(),
+            content: format_edit_preview_at(shown, matched, new_string, count, start),
+            is_error: false,
+        },
+        Err(e) => ToolResult {
+            tool_call_id: String::new(),
+            content: format!("Error writing file: {e}"),
+            is_error: true,
+        },
+    }
+}
+
+fn apply_tagged(
+    original: &str,
+    from: Option<&str>,
+    to: Option<&str>,
+    insert_after: Option<&str>,
+    new_string: &str,
+) -> Result<(String, String, Option<usize>), String> {
+    use crate::file::line_tag::{
+        MIN_LEN, TagHit, find_tag, line_offsets, line_text, nearby_snippet, tag_of,
+    };
+
+    if from.is_some() && insert_after.is_some() {
+        return Err("Use either from/to or insert_after, not both.".into());
+    }
+    let offs = line_offsets(original);
+    if offs.is_empty() {
+        return Err("File is empty — tags cannot be resolved.".into());
+    }
+
+    let resolve = |tag: &str, label: &str| -> Result<usize, String> {
+        match find_tag(original, &offs, tag) {
+            TagHit::Unique(i) => Ok(i),
+            TagHit::Missing => Err(format!(
+                "Content tag `{tag}` ({label}) was not found. File may have changed.\n{}",
+                nearby_snippet(original, &offs, 0, 4)
+            )),
+            TagHit::Ambiguous(hits) => {
+                let mut msg = format!(
+                    "Content tag `{tag}` ({label}) matches {} lines. Use a longer tag from the last `read`.\n",
+                    hits.len()
+                );
+                for i in hits.iter().take(8) {
+                    let text = line_text(original, offs[*i]);
+                    let t = tag_of(text, MIN_LEN.max(tag.len()));
+                    msg.push_str(&crate::file::line_tag::format_read_line(i + 1, &t, text));
+                    msg.push('\n');
+                }
+                Err(msg)
+            }
+        }
+    };
+
+    if let Some(after) = insert_after {
+        let i = resolve(after, "insert_after")?;
+        let insert_at = offs[i].line_end;
+        let mut insert = new_string.to_string();
+        if !insert.is_empty() && !insert.ends_with('\n') {
+            insert.push('\n');
+        }
+        if !insert.is_empty() && insert_at > 0 && !original[..insert_at].ends_with('\n') {
+            insert.insert(0, '\n');
+        }
+        let mut modified = String::with_capacity(original.len() + insert.len());
+        modified.push_str(&original[..insert_at]);
+        modified.push_str(&insert);
+        modified.push_str(&original[insert_at..]);
+        return Ok((String::new(), modified, Some(i + 2)));
+    }
+
+    let from_tag =
+        from.ok_or_else(|| "from is required when insert_after is not set.".to_string())?;
+    let start_i = resolve(from_tag, "from")?;
+    let end_i = if let Some(to_tag) = to {
+        let j = resolve(to_tag, "to")?;
+        if j < start_i {
+            return Err("`to` must not precede `from`.".into());
+        }
+        j
+    } else {
+        start_i
+    };
+    let byte_start = offs[start_i].start;
+    let byte_end = offs[end_i].line_end;
+    let matched = original[byte_start..byte_end].to_string();
+    let modified = apply_spans(original, &[(byte_start, byte_end)], new_string);
+    Ok((matched, modified, Some(start_i + 1)))
+}
+
+fn miss_with_snippet(original: &str, old: &str) -> String {
+    use crate::file::line_tag::{line_offsets, nearby_snippet};
+    let offs = line_offsets(original);
+    let mut center = 0usize;
+    if let Some(tok) = old.split_whitespace().next()
+        && let Some(pos) = original.find(tok)
+    {
+        center = original[..pos].bytes().filter(|&b| b == b'\n').count();
+    }
+    format!(
+        "Could not find the specified text in the file.\nNearby lines:\n{}",
+        nearby_snippet(original, &offs, center, 3)
+    )
+}
+
+fn ambiguous_with_tags(original: &str, old: &str, count: usize) -> String {
+    use crate::file::line_tag::{MIN_LEN, format_read_line, line_offsets, line_text, tag_of};
+    let offs = line_offsets(original);
+    let mut msg = format!(
+        "Found {count} occurrences of the search text. Use replace_all=true, a more specific match, or a content tag.\n"
+    );
+    let mut shown = 0usize;
+    let mut from = 0usize;
+    while shown < 6 && from < original.len() {
+        if let Some(rel) = original[from..].find(old) {
+            let abs = from + rel;
+            let line_i = original[..abs].bytes().filter(|&b| b == b'\n').count();
+            if line_i < offs.len() {
+                let text = line_text(original, offs[line_i]);
+                let tag = tag_of(text, MIN_LEN);
+                msg.push_str(&format_read_line(line_i + 1, &tag, text));
+                msg.push('\n');
+                shown += 1;
+            }
+            from = abs + old.len().max(1);
+        } else {
+            break;
+        }
+    }
+    msg
 }
 
 enum Locate {

--- a/crates/tools/src/file/edit_tests.rs
+++ b/crates/tools/src/file/edit_tests.rs
@@ -113,6 +113,190 @@ async fn execute_replaces_text_and_reports_missing() {
         .await;
     assert!(miss.is_error, "{}", miss.content);
     assert!(miss.content.contains("Could not find"), "{}", miss.content);
+    assert!(miss.content.contains("Nearby lines:"), "{}", miss.content);
+}
+
+#[tokio::test]
+async fn execute_replaces_by_from_to_tags() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("a.rs");
+    std::fs::write(&path, "fn run() {\n    let x = 1;\n}\n").unwrap();
+    let from = crate::file::line_tag::tag_of("    let x = 1;", 2);
+    let tool = EditTool::new();
+    let ok = tool
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "from": from,
+                "new_string": "    let x = 2;\n"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(!ok.is_error, "{}", ok.content);
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "fn run() {\n    let x = 2;\n}\n"
+    );
+}
+
+#[tokio::test]
+async fn execute_insert_after_tag() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("a.rs");
+    std::fs::write(&path, "fn run() {\n    let x = 1;\n}\n").unwrap();
+    let after = crate::file::line_tag::tag_of("    let x = 1;", 2);
+    let ok = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "insert_after": after,
+                "new_string": "    let y = 3;"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(!ok.is_error, "{}", ok.content);
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "fn run() {\n    let x = 1;\n    let y = 3;\n}\n"
+    );
+}
+
+#[tokio::test]
+async fn execute_insert_after_last_line_without_newline() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("a.rs");
+    std::fs::write(&path, "fn run() {}").unwrap();
+    let after = crate::file::line_tag::tag_of("fn run() {}", 2);
+    let ok = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "insert_after": after,
+                "new_string": "fn go() {}"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(!ok.is_error, "{}", ok.content);
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "fn run() {}\nfn go() {}\n"
+    );
+}
+
+#[tokio::test]
+async fn execute_replaces_from_to_range() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("a.rs");
+    std::fs::write(&path, "fn run() {\n    let x = 1;\n    let y = 2;\n}\n").unwrap();
+    let from = crate::file::line_tag::tag_of("    let x = 1;", 2);
+    let to = crate::file::line_tag::tag_of("    let y = 2;", 2);
+    let ok = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "from": from,
+                "to": to,
+                "new_string": "    let z = 3;\n"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(!ok.is_error, "{}", ok.content);
+    assert_eq!(
+        std::fs::read_to_string(&path).unwrap(),
+        "fn run() {\n    let z = 3;\n}\n"
+    );
+}
+
+#[tokio::test]
+async fn execute_tagged_error_paths() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("a.rs");
+    std::fs::write(&path, "fn run() {\n    let x = 1;\n    let x = 1;\n}\n").unwrap();
+    let tag = crate::file::line_tag::tag_of("    let x = 1;", 2);
+    let both = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "from": tag,
+                "insert_after": tag,
+                "new_string": "nope"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(both.is_error, "{}", both.content);
+    assert!(both.content.contains("not both"), "{}", both.content);
+
+    let amb = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "from": tag,
+                "new_string": "    let y = 2;\n"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(amb.is_error, "{}", amb.content);
+    assert!(amb.content.contains("matches"), "{}", amb.content);
+
+    let close = crate::file::line_tag::tag_of("}", 2);
+    let order = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "from": close,
+                "to": crate::file::line_tag::tag_of("fn run() {", 2),
+                "new_string": "x"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(order.is_error, "{}", order.content);
+    assert!(
+        order.content.contains("must not precede"),
+        "{}",
+        order.content
+    );
+
+    std::fs::write(&path, "").unwrap();
+    let empty = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "from": "aa",
+                "new_string": "x"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(empty.is_error, "{}", empty.content);
+    assert!(empty.content.contains("empty"), "{}", empty.content);
+}
+
+#[tokio::test]
+async fn execute_stale_tag_does_not_write() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("a.rs");
+    std::fs::write(&path, "fn run() {}\n").unwrap();
+    let before = std::fs::read_to_string(&path).unwrap();
+    let miss = EditTool::new()
+        .execute(
+            serde_json::json!({
+                "path": "a.rs",
+                "from": "zz",
+                "new_string": "nope"
+            }),
+            &ctx(dir.path()),
+        )
+        .await;
+    assert!(miss.is_error, "{}", miss.content);
+    assert!(miss.content.contains("was not found"), "{}", miss.content);
+    assert_eq!(std::fs::read_to_string(&path).unwrap(), before);
 }
 
 #[tokio::test]

--- a/crates/tools/src/file/grep.rs
+++ b/crates/tools/src/file/grep.rs
@@ -35,7 +35,8 @@ impl Tool for GrepTool {
     fn description(&self) -> &str {
         "Search file contents with regex (ripgrep engine, in-process — no `rg` binary). \
          Respects .gitignore; skips binaries and heavy dirs (target, node_modules, .git, …). \
-         Prefer over shell grep for project code search."
+         Prefer over shell grep for project code search. Hits are \
+         `path:line tag:text` so `edit` can name the line by tag."
     }
 
     fn parameters(&self) -> serde_json::Value {
@@ -344,7 +345,7 @@ impl GrepTool {
     }
 }
 
-/// Collects ripgrep sink events into the existing `path:line:text` format.
+/// Collects ripgrep sink events into `path:line tag:text` (context uses `-`).
 struct CollectSink<'a> {
     display: &'a str,
     matches: &'a mut Vec<String>,
@@ -364,11 +365,13 @@ impl Sink for CollectSink<'_> {
         }
         let lineno = mat.line_number().unwrap_or(0);
         let line = utf8_line(mat.bytes());
-        self.matches.push(format!(
-            "{}:{}:{}",
+        let tag = super::line_tag::tag_of(&line, super::line_tag::MIN_LEN);
+        self.matches.push(super::line_tag::format_grep_line(
             self.display,
             lineno,
-            clip_line(&line, 500)
+            &tag,
+            &clip_line(&line, 500),
+            ':',
         ));
         Ok(self.matches.len() < self.max_results)
     }
@@ -383,11 +386,13 @@ impl Sink for CollectSink<'_> {
         }
         let lineno = ctx.line_number().unwrap_or(0);
         let line = utf8_line(ctx.bytes());
-        self.matches.push(format!(
-            "{}:{}-{}",
+        let tag = super::line_tag::tag_of(&line, super::line_tag::MIN_LEN);
+        self.matches.push(super::line_tag::format_grep_line(
             self.display,
             lineno,
-            clip_line(&line, 500)
+            &tag,
+            &clip_line(&line, 500),
+            '-',
         ));
         Ok(true)
     }

--- a/crates/tools/src/file/grep_tests.rs
+++ b/crates/tools/src/file/grep_tests.rs
@@ -24,8 +24,10 @@ fn search_single_file_matches() {
     let dir = TempDir::new().unwrap();
     let f = write(&dir, "a.txt", "hello world\nfoo bar\nhello again\n");
     let out = GrepTool::search("hello", &f, None, false, 0, 50, "/", None).unwrap();
-    assert!(out.contains("a.txt:1:hello world"));
-    assert!(out.contains("a.txt:3:hello again"));
+    assert!(out.contains("a.txt:1 "));
+    assert!(out.contains(":hello world"));
+    assert!(out.contains("a.txt:3 "));
+    assert!(out.contains(":hello again"));
     assert!(out.contains("(2 matches in 1 file"));
 }
 
@@ -75,9 +77,12 @@ fn search_context_lines() {
     let dir = TempDir::new().unwrap();
     let f = write(&dir, "a.txt", "before\nmatch\nafter\n");
     let out = GrepTool::search("match", &f, None, false, 1, 50, "/", None).unwrap();
-    assert!(out.contains("a.txt:1-before"));
-    assert!(out.contains("a.txt:2:match"));
-    assert!(out.contains("a.txt:3-after"));
+    assert!(out.contains("a.txt:1 "));
+    assert!(out.contains("-before"));
+    assert!(out.contains("a.txt:2 "));
+    assert!(out.contains(":match"));
+    assert!(out.contains("a.txt:3 "));
+    assert!(out.contains("-after"));
     assert!(out.contains("--"));
 }
 
@@ -184,7 +189,8 @@ fn search_context_includes_markers_only_between() {
     // Two matches with context should not end with a lone `--` at EOF boundary
     let f = write(&dir, "a.txt", "x\n\n\n");
     let out = GrepTool::search("x", &f, None, false, 1, 50, "/", None).unwrap();
-    assert!(out.contains("a.txt:1:x"));
+    assert!(out.contains("a.txt:1 "), "{out}");
+    assert!(out.contains(":x"), "{out}");
 }
 
 #[tokio::test]

--- a/crates/tools/src/file/line_tag.rs
+++ b/crates/tools/src/file/line_tag.rs
@@ -1,0 +1,170 @@
+//! Short content tags for `read` / `grep` lines, so `edit` can name a span
+//! without reciting `old_string` byte-for-byte.
+//!
+//! A tag is a base36 prefix of an FxHash of the line text (no trailing newline).
+//! Same content always hashes the same. Different content in one window is
+//! lengthened until the prefixes diverge. Lookup at edit time uses the length
+//! of the caller-supplied tag against the whole file and fails closed on
+//! missing or ambiguous hits.
+
+use rustc_hash::FxHasher;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+
+const ALPH: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyz";
+pub const MIN_LEN: usize = 2;
+pub const MAX_LEN: usize = 6;
+
+pub fn hash_u64(line: &str) -> u64 {
+    let mut h = FxHasher::default();
+    line.hash(&mut h);
+    h.finish()
+}
+
+pub fn encode(hash: u64, len: usize) -> String {
+    let len = len.clamp(MIN_LEN, MAX_LEN);
+    // Always emit MAX_LEN digits (MSB first) so a shorter tag is a prefix of a
+    // longer one for the same line.
+    let mut n = hash;
+    let mut digits = [b'0'; MAX_LEN];
+    for slot in digits.iter_mut().rev() {
+        *slot = ALPH[(n % 36) as usize];
+        n /= 36;
+    }
+    digits[..len].iter().map(|&b| b as char).collect()
+}
+
+pub fn tag_of(line: &str, len: usize) -> String {
+    encode(hash_u64(line), len)
+}
+
+/// Tags for a visible window. Lengthen until different contents get different tags.
+pub fn tags_for_window(lines: &[&str]) -> Vec<String> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+    for len in MIN_LEN..=MAX_LEN {
+        let tags: Vec<String> = lines.iter().map(|l| tag_of(l, len)).collect();
+        if content_tags_unique(lines, &tags) {
+            return tags;
+        }
+    }
+    lines.iter().map(|l| tag_of(l, MAX_LEN)).collect()
+}
+
+fn content_tags_unique(lines: &[&str], tags: &[String]) -> bool {
+    let mut first: HashMap<&str, &str> = HashMap::new();
+    for (line, tag) in lines.iter().zip(tags) {
+        if let Some(prev) = first.insert(tag.as_str(), line)
+            && prev != *line
+        {
+            return false;
+        }
+    }
+    true
+}
+
+/// `     42 a3|contents`
+pub fn format_read_line(n: usize, tag: &str, line: &str) -> String {
+    format!("{n:6} {tag}|{line}")
+}
+
+/// `path:12 a3:contents` or `path:12 a3-contents` for context rows.
+pub fn format_grep_line(path: &str, n: u64, tag: &str, line: &str, sep: char) -> String {
+    format!("{path}:{n} {tag}{sep}{line}")
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct LineOffsets {
+    /// Byte offset of the first content byte.
+    pub start: usize,
+    /// Byte offset past the last content byte (before `\n` if any).
+    pub content_end: usize,
+    /// Byte offset past the line terminator (`\n` / `\r\n`) or `content_end`.
+    pub line_end: usize,
+}
+
+/// Split `s` into logical lines with byte offsets. A trailing newline does not
+/// add an extra empty line (matches `str::lines`).
+pub fn line_offsets(s: &str) -> Vec<LineOffsets> {
+    let mut out = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let start = i;
+        while i < bytes.len() && bytes[i] != b'\n' && bytes[i] != b'\r' {
+            i += 1;
+        }
+        let content_end = i;
+        if i < bytes.len() && bytes[i] == b'\r' {
+            i += 1;
+        }
+        if i < bytes.len() && bytes[i] == b'\n' {
+            i += 1;
+        }
+        out.push(LineOffsets {
+            start,
+            content_end,
+            line_end: i,
+        });
+        if start == i {
+            break;
+        }
+    }
+    out
+}
+
+pub fn line_text(s: &str, off: LineOffsets) -> &str {
+    &s[off.start..off.content_end]
+}
+
+#[derive(Debug)]
+pub enum TagHit {
+    Unique(usize),
+    Missing,
+    Ambiguous(Vec<usize>),
+}
+
+pub fn find_tag(s: &str, offs: &[LineOffsets], tag: &str) -> TagHit {
+    let len = tag.len();
+    if !(MIN_LEN..=MAX_LEN).contains(&len) || !tag.bytes().all(is_tag_char) {
+        return TagHit::Missing;
+    }
+    let mut hits = Vec::new();
+    for (i, off) in offs.iter().enumerate() {
+        if tag_of(line_text(s, *off), len) == tag {
+            hits.push(i);
+        }
+    }
+    match hits.len() {
+        0 => TagHit::Missing,
+        1 => TagHit::Unique(hits[0]),
+        _ => TagHit::Ambiguous(hits),
+    }
+}
+
+fn is_tag_char(b: u8) -> bool {
+    b.is_ascii_digit() || b.is_ascii_lowercase()
+}
+
+/// Nearby tagged lines for a failed lookup (`center` is a line index, or 0).
+pub fn nearby_snippet(s: &str, offs: &[LineOffsets], center: usize, radius: usize) -> String {
+    if offs.is_empty() {
+        return "(empty file)".into();
+    }
+    let len = MIN_LEN;
+    let from = center.saturating_sub(radius);
+    let to = (center + radius + 1).min(offs.len());
+    let mut out = String::new();
+    for (i, off) in offs.iter().enumerate().take(to).skip(from) {
+        let text = line_text(s, *off);
+        let tag = tag_of(text, len);
+        out.push_str(&format_read_line(i + 1, &tag, text));
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+#[path = "line_tag_tests.rs"]
+mod tests;

--- a/crates/tools/src/file/line_tag_tests.rs
+++ b/crates/tools/src/file/line_tag_tests.rs
@@ -1,0 +1,135 @@
+use super::*;
+
+#[test]
+fn encode_is_stable_and_ascii() {
+    let a = tag_of("hello", 2);
+    let b = tag_of("hello", 2);
+    assert_eq!(a, b);
+    assert_eq!(a.len(), 2);
+    assert!(a.bytes().all(is_tag_char));
+    assert_ne!(tag_of("hello", 2), tag_of("world", 2));
+}
+
+#[test]
+fn longer_prefix_extends_shorter() {
+    let h = hash_u64("a distinct line of source");
+    let two = encode(h, 2);
+    let three = encode(h, 3);
+    assert!(three.starts_with(&two), "{three} should start with {two}");
+}
+
+#[test]
+fn window_lengthens_on_content_collision() {
+    // Two different strings that collide at len=2 are rare; force uniqueness
+    // by checking the helper never maps different contents to one tag.
+    let lines = ["alpha", "bravo", "alpha"];
+    let tags = tags_for_window(&lines);
+    assert_eq!(tags.len(), 3);
+    assert_eq!(tags[0], tags[2], "identical content shares a tag");
+    assert_ne!(tags[0], tags[1]);
+}
+
+#[test]
+fn window_lengthens_when_short_prefixes_collide() {
+    let mut first: Option<(String, String)> = None;
+    let mut second = None;
+    for i in 0..50_000 {
+        let s = format!("line-{i}");
+        let t = tag_of(&s, MIN_LEN);
+        match &first {
+            None => first = Some((s, t)),
+            Some((a, at)) if at == &t && a != &s => {
+                second = Some(s);
+                break;
+            }
+            _ => {}
+        }
+    }
+    let (a, short) = first.expect("hashed a candidate");
+    let b = second.expect("two distinct lines sharing a MIN_LEN tag");
+    let tags = tags_for_window(&[&a, &b]);
+    assert_ne!(tags[0], tags[1]);
+    assert!(tags[0].len() > MIN_LEN, "{} vs short {short}", tags[0]);
+    assert!(tags[0].starts_with(&short) || tags[1].starts_with(&tag_of(&b, MIN_LEN)));
+}
+
+#[test]
+fn find_tag_unique_missing_ambiguous() {
+    let s = "one\ntwo\none\n";
+    let offs = line_offsets(s);
+    assert_eq!(offs.len(), 3);
+    let t2 = tag_of("two", 2);
+    match find_tag(s, &offs, &t2) {
+        TagHit::Unique(i) => assert_eq!(i, 1),
+        other => panic!("expected unique, got {other:?}"),
+    }
+    match find_tag(s, &offs, "zz") {
+        TagHit::Missing => {}
+        other => panic!("expected missing, got {other:?}"),
+    }
+    let t1 = tag_of("one", 2);
+    match find_tag(s, &offs, &t1) {
+        TagHit::Ambiguous(hits) => assert_eq!(hits, vec![0, 2]),
+        other => panic!("expected ambiguous, got {other:?}"),
+    }
+}
+
+#[test]
+fn line_offsets_crlf_and_no_trailing_empty() {
+    let s = "a\r\nb\n";
+    let offs = line_offsets(s);
+    assert_eq!(offs.len(), 2);
+    assert_eq!(line_text(s, offs[0]), "a");
+    assert_eq!(line_text(s, offs[1]), "b");
+}
+
+#[test]
+fn format_read_and_grep_shapes() {
+    let line = format_read_line(42, "a3", "    let x = 1;");
+    assert!(line.contains("42"));
+    assert!(line.contains(" a3|"));
+    assert!(line.ends_with("let x = 1;"));
+    let g = format_grep_line("src/a.rs", 7, "k9", "fn run()", ':');
+    assert_eq!(g, "src/a.rs:7 k9:fn run()");
+}
+
+#[test]
+fn encode_clamps_and_empty_window() {
+    let h = hash_u64("x");
+    assert_eq!(encode(h, 1).len(), MIN_LEN);
+    assert_eq!(encode(h, 99).len(), MAX_LEN);
+    assert!(tags_for_window(&[]).is_empty());
+}
+
+#[test]
+fn find_tag_rejects_bad_tokens() {
+    let s = "alpha\n";
+    let offs = line_offsets(s);
+    for bad in ["", "a", "ABCDEF", "a1!", "abcdefg"] {
+        match find_tag(s, &offs, bad) {
+            TagHit::Missing => {}
+            other => panic!("expected missing for {bad:?}, got {other:?}"),
+        }
+    }
+}
+
+#[test]
+fn line_offsets_empty_and_no_terminator() {
+    assert!(line_offsets("").is_empty());
+    let s = "solo";
+    let offs = line_offsets(s);
+    assert_eq!(offs.len(), 1);
+    assert_eq!(line_text(s, offs[0]), "solo");
+    assert_eq!(offs[0].line_end, s.len());
+}
+
+#[test]
+fn nearby_snippet_empty_and_window() {
+    assert_eq!(nearby_snippet("", &[], 0, 2), "(empty file)");
+    let s = "a\nb\nc\n";
+    let offs = line_offsets(s);
+    let snip = nearby_snippet(s, &offs, 1, 1);
+    assert!(snip.contains("|a"), "{snip}");
+    assert!(snip.contains("|b"), "{snip}");
+    assert!(snip.contains("|c"), "{snip}");
+}

--- a/crates/tools/src/file/mod.rs
+++ b/crates/tools/src/file/mod.rs
@@ -5,6 +5,7 @@ pub mod external_directory;
 pub mod glob;
 pub mod grep;
 pub mod internal;
+pub(crate) mod line_tag;
 pub mod list;
 pub mod paths;
 pub mod read;

--- a/crates/tools/src/file/read.rs
+++ b/crates/tools/src/file/read.rs
@@ -35,6 +35,8 @@ impl Tool for ReadTool {
 
     fn description(&self) -> &str {
         "Read a text file (line-numbered). Prefer project-relative paths. \
+         Each line is `N tag|text` — pass `from`/`to`/`insert_after` on `edit` \
+         instead of reciting `old_string`. \
          Use offset/limit for large files instead of reading everything. \
          `skill://<name>` loads a skill body; `agent://<id>` re-reads a finished \
          task/swarm artifact (empty id lists them). \
@@ -189,11 +191,14 @@ impl ReadTool {
                     },
                     super::paths::human_size(size)
                 ));
+                let refs: Vec<&str> = window.lines.iter().map(String::as_str).collect();
+                let tags = super::line_tag::tags_for_window(&refs);
                 for (i, line) in window.lines.iter().enumerate() {
                     let n = window.start_line + i;
                     // Cap absurdly long lines to protect context
                     let line = truncate_line(line, 4000);
-                    out.push_str(&format!("{:6}|{}\n", n, line));
+                    out.push_str(&super::line_tag::format_read_line(n, &tags[i], &line));
+                    out.push('\n');
                 }
                 if window.truncated {
                     out.push_str(&format!(

--- a/crates/tools/src/file/read_tests.rs
+++ b/crates/tools/src/file/read_tests.rs
@@ -123,8 +123,10 @@ async fn execute_reads_window_with_header() {
         .await;
     assert!(!result.is_error);
     assert!(result.content.contains("# lines 2–3 of 3"));
-    assert!(result.content.contains("2|two"));
-    assert!(result.content.contains("3|three"));
+    assert!(result.content.contains("2 "));
+    assert!(result.content.contains("|two"));
+    assert!(result.content.contains("3 "));
+    assert!(result.content.contains("|three"));
 }
 
 #[tokio::test]
@@ -133,7 +135,7 @@ async fn execute_missing_file_suggests() {
     write(&dir, "readme.md", "x");
     let ctx = ToolContext::new(dir.path().to_string_lossy().into_owned());
     let result = ReadTool::new()
-        .execute(serde_json::json!({"path": "Readme.md"}), &ctx)
+        .execute(serde_json::json!({"path": "readme.txt"}), &ctx)
         .await;
     assert!(result.is_error);
     assert!(result.content.contains("File not found"));


### PR DESCRIPTION
## Summary
`read` / `grep` now print a short prefix-stable content tag on each line (`N tag|text`, `path:line tag:text`). `edit` accepts `from` / `to` / `insert_after` and fails closed on missing or ambiguous tags. `old_string` stays the fallback.

Also forwards `bundled-sqlite` through `whycodes-memory` / `whycodes-tools` so Windows tests can link without a system `sqlite3.lib`.

Closes #74

## Test plan
- [x] `cargo test -p whycodes-tools --lib --features bundled-sqlite file::`
- [x] `cargo clippy -p whycodes-tools --all-targets --features bundled-sqlite -- -D warnings`
- [x] budget scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)