### PR TITLE
build: pin rustfmt, clippy groups, and faster dev compiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,9 @@ jobs:
           '
       - uses: taiki-e/install-action@v2
         with:
-          tool: cargo-audit
+          tool: cargo-audit,cargo-deny
+      - name: cargo deny (licenses + sources)
+        run: cargo deny check licenses sources
       - name: cargo audit
         run: cargo audit --deny warnings
       - name: TypeScript SDK — build and test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,12 @@ Whenever you edit Rust source, `Cargo.toml`, or anything that affects compilatio
    cargo clippy -p whycodes-<crate> --all-targets -- -D warnings
    ```
 
+   Formatter/clippy policy lives in-tree: `rustfmt.toml` +
+   `[workspace.lints.clippy]` (`correctness` / `suspicious` deny). CI
+   `clippy -- -D warnings` is unchanged. License/source gate is
+   `cargo deny check licenses sources` (`deny.toml`); advisories stay on
+   `cargo audit`.
+
    A `let _ = send(...)`, `Err(_) =>`, `return x.ok();`, or a new `whycodes-*` Cargo.toml line will fail CI even when the crate compiles. Handle the error (name it / log it) or register the edge in `scripts/dependency_boundaries.json` in the **same** commit. Details: [`docs/knowhow.md`](docs/knowhow.md) rule 8.
 
 ### Why

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,16 @@ python scripts/check_swallowed_error_budget.py
 python scripts/check_dependency_boundaries.py
 python scripts/check_sdk_protocol.py   # Rust ↔ TypeScript protocol v1 tags
 python scripts/check_tracked_secrets.py
+cargo deny check licenses sources      # license / crates.io-only sources
+cargo audit --deny warnings            # advisories (see .cargo/audit.toml)
 ```
+
+Formatter knobs live in `rustfmt.toml` (edition 2024, 100 columns, stable
+keys only). rust-analyzer matches that via `rust-analyzer.toml`.
+Workspace Clippy policy is `[workspace.lints.clippy]` in the root `Cargo.toml`
+(`correctness` / `suspicious` deny). CI still passes `-D warnings` on the
+default group. License/source policy is `deny.toml`; advisory ignores stay in
+`.cargo/audit.toml`.
 
 Dev builds use system SQLite (`pkg-config sqlite3`). CI and release enable
 `whycodes-storage/bundled` / `whycodes-cli/bundled-sqlite` so the self-hosted

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,6 +85,13 @@ codegen-units = 256
 # Keep debuginfo line-tables for backtraces without full DWARF cost.
 debug = 1
 
+# Workspace deps (`tokio`, `serde`, `reqwest`, `rusqlite`, …) compile once
+# optimized. First-party crates stay opt-level 0 / debug 1. Does not change
+# the shipped `release` binary.
+[profile.dev.package."*"]
+opt-level = 2
+debug = false
+
 # Release: smallest ship binary + hot-path inlining (format, risk, TUI).
 # full LTO (was thin) + panic=abort cuts page-in for Boot/TTFF (`--version`).
 # Link is slower; use `cargo build -p whycodes-cli` for day-to-day, not full release.
@@ -94,6 +101,27 @@ codegen-units = 1
 strip = true
 panic = "abort"
 
+# Line tables, no strip — `cargo build --profile profiling -p whycodes-cli`.
+# Not wired into CI.
+[profile.profiling]
+inherits = "release"
+debug = "line-tables-only"
+strip = false
+
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "warn"
+
+# Inherited by every crate (`[lints] workspace = true`). CI still runs
+# `clippy -- -D warnings` on the default group; this table is the local
+# rust-analyzer / bare `cargo clippy` policy.
+[workspace.lints.clippy]
+# Groups must sit below individual lints (`priority = -1`) or Clippy
+# rejects the table (`lint_groups_priority`).
+#
+# `undocumented_unsafe_blocks` is a restriction lint. Setting it to warn
+# here would fail CI (`-D warnings`): Rust 2024 made `env::set_var` unsafe,
+# so tests have dozens of undocumented blocks. Keep it off the table until
+# those sites get SAFETY comments.
+correctness = { level = "deny", priority = -1 }
+suspicious = { level = "deny", priority = -1 }
 

--- a/crates/function/Cargo.toml
+++ b/crates/function/Cargo.toml
@@ -3,6 +3,8 @@ name = "whycodes-function"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 whycodes-core = { path = "../core" }

--- a/crates/protocol/Cargo.toml
+++ b/crates/protocol/Cargo.toml
@@ -3,6 +3,8 @@ name = "whycodes-protocol"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -3,6 +3,8 @@ name = "whycodes-schema"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 serde.workspace = true

--- a/crates/tools/src/agent_tools/memory_tests.rs
+++ b/crates/tools/src/agent_tools/memory_tests.rs
@@ -1,46 +1,59 @@
 use super::*;
 use crate::tool::ToolContext;
 
-static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
 struct IsolatedHome {
     _guard: std::sync::MutexGuard<'static, ()>,
     dir: tempfile::TempDir,
     prev: Option<std::ffi::OsString>,
     prev_no_memory: Option<std::ffi::OsString>,
+    prev_git_dir: Option<std::ffi::OsString>,
+    prev_git_work_tree: Option<std::ffi::OsString>,
+}
+
+fn restore_os(key: &str, prev: Option<&std::ffi::OsString>) {
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var(key, v),
+            None => std::env::remove_var(key),
+        }
+    }
 }
 
 impl IsolatedHome {
     fn new() -> Self {
-        let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let guard = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().expect("tempdir");
         let prev = std::env::var_os("WHYCODES_HOME");
         let prev_no_memory = std::env::var_os("WHYCODES_NO_MEMORY");
+        let prev_git_dir = std::env::var_os("GIT_DIR");
+        let prev_git_work_tree = std::env::var_os("GIT_WORK_TREE");
         unsafe {
             std::env::set_var("WHYCODES_HOME", dir.path());
             std::env::remove_var("WHYCODES_NO_MEMORY");
+            // A runner-set GIT_DIR would make `git rev-parse --show-toplevel`
+            // from this tempdir return the checkout, so every isolated test
+            // would share one project_key (and a leaked HOME would write into
+            // the runner's real memory DB).
+            std::env::remove_var("GIT_DIR");
+            std::env::remove_var("GIT_WORK_TREE");
         }
         Self {
             _guard: guard,
             dir,
             prev,
             prev_no_memory,
+            prev_git_dir,
+            prev_git_work_tree,
         }
     }
 }
 
 impl Drop for IsolatedHome {
     fn drop(&mut self) {
-        unsafe {
-            match &self.prev {
-                Some(v) => std::env::set_var("WHYCODES_HOME", v),
-                None => std::env::remove_var("WHYCODES_HOME"),
-            }
-            match &self.prev_no_memory {
-                Some(v) => std::env::set_var("WHYCODES_NO_MEMORY", v),
-                None => std::env::remove_var("WHYCODES_NO_MEMORY"),
-            }
-        }
+        restore_os("WHYCODES_HOME", self.prev.as_ref());
+        restore_os("WHYCODES_NO_MEMORY", self.prev_no_memory.as_ref());
+        restore_os("GIT_DIR", self.prev_git_dir.as_ref());
+        restore_os("GIT_WORK_TREE", self.prev_git_work_tree.as_ref());
     }
 }
 

--- a/crates/tools/src/executor_tests.rs
+++ b/crates/tools/src/executor_tests.rs
@@ -395,7 +395,9 @@ async fn execute_unknown_in_isolated_executor_lists_registered() {
 #[test]
 fn register_config_plugins_project_toml() {
     // Isolate global config so the developer machine's plugins.toml cannot leak in.
+    let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let home = tempfile::tempdir().unwrap();
+    let prev = std::env::var_os("WHYCODES_HOME");
     unsafe { std::env::set_var("WHYCODES_HOME", home.path()) };
     let dir = tempfile::tempdir().unwrap();
     let why = dir.path().join(".whycodes");
@@ -423,18 +425,30 @@ description = "Has no command"
     assert_eq!(shout.unwrap().description(), "Shouts back");
     // Empty-command plugins are skipped.
     assert!(ex.get("plugin_empty-cmd").is_none());
-    unsafe { std::env::remove_var("WHYCODES_HOME") };
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("WHYCODES_HOME", v),
+            None => std::env::remove_var("WHYCODES_HOME"),
+        }
+    }
 }
 
 #[test]
 fn register_config_plugins_skips_without_project_dir() {
     // No project dir: falls back to isolated (empty) global config only.
+    let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let home = tempfile::tempdir().unwrap();
+    let prev = std::env::var_os("WHYCODES_HOME");
     unsafe { std::env::set_var("WHYCODES_HOME", home.path()) };
     let mut ex = ToolExecutor::new();
     let n = ex.register_config_plugins(None);
     assert_eq!(n, 0);
-    unsafe { std::env::remove_var("WHYCODES_HOME") };
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("WHYCODES_HOME", v),
+            None => std::env::remove_var("WHYCODES_HOME"),
+        }
+    }
 }
 
 #[test]
@@ -442,6 +456,7 @@ fn register_config_plugins_invalid_toml_and_empty_json_name() {
     let _g = crate::ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     let home = tempfile::tempdir().unwrap();
     std::fs::write(home.path().join("plugins.toml"), "[[plugins]]\nname = [").unwrap();
+    let prev = std::env::var_os("WHYCODES_HOME");
     unsafe { std::env::set_var("WHYCODES_HOME", home.path()) };
 
     let dir = tempfile::tempdir().unwrap();
@@ -457,5 +472,10 @@ fn register_config_plugins_invalid_toml_and_empty_json_name() {
     let _ = ex.register_config_plugins(Some(dir.path()));
     let n = ex.register_config_plugins(None);
     assert_eq!(n, 0);
-    unsafe { std::env::remove_var("WHYCODES_HOME") };
+    unsafe {
+        match prev {
+            Some(v) => std::env::set_var("WHYCODES_HOME", v),
+            None => std::env::remove_var("WHYCODES_HOME"),
+        }
+    }
 }

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,51 @@
+# License + source policy. Advisories stay on `cargo audit` + `.cargo/audit.toml`.
+# CI: `cargo deny check licenses sources`
+
+[graph]
+all-features = false
+no-default-features = false
+exclude-dev = false
+
+[output]
+feature-depth = 1
+
+[advisories]
+# Not used. `cargo audit --deny warnings` is the advisory gate.
+yanked = "warn"
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "CDLA-Permissive-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-3.0",
+    "Zlib",
+    "CC0-1.0",
+    "MPL-2.0",
+    "OpenSSL",
+    "BSL-1.0",
+    "0BSD",
+    "Unlicense",
+]
+confidence-threshold = 0.8
+unused-allowed-license = "allow"
+
+[licenses.private]
+ignore = true
+
+[bans]
+multiple-versions = "allow"
+wildcards = "allow"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/docs/rust-best-practices.md
+++ b/docs/rust-best-practices.md
@@ -36,6 +36,10 @@ Bunlar bilinçli ve korunmalı:
 - **Crate katmanları** (`docs/architecture.md`) + `scripts/dependency_boundaries.json`.
 - **Panic / swallowed-error ratchet.** Çoğu crate panic bütçesi 0.
 - **Clippy `-D warnings`**, `cargo fmt`, `cargo-audit` ignore listesi tarihli.
+  Formatter ve Clippy artık sadece CI’de değil: `rustfmt.toml` +
+  `[workspace.lints.clippy]` (`correctness` / `suspicious` deny). Lisans/kaynak
+  kapısı `deny.toml` (`cargo deny check licenses sources`); advisory ignore’lar
+  `.cargo/audit.toml`’da kalır.
 - `tools/src/blocking.rs`: senkron FS/`Command` işini Tokio worker’dan ayırma.
 - `LlmRequest.messages: Arc<[Message]>` + `messages_mut()` COW — clone maliyetine dair yorum doğru.
 - `logging.rs` mutex poison’ı `expect` yerine `io::Error`’a çeviriyor.

--- a/rust-analyzer.toml
+++ b/rust-analyzer.toml
@@ -1,0 +1,5 @@
+# rust-analyzer reads rustfmt.toml next to Cargo.toml automatically.
+# Use Clippy as the on-save check so the workspace lint table applies
+# locally, not only under CI `-D warnings`.
+[check]
+command = "clippy"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,10 @@
+# Stable rustfmt only. Nightly knobs (`imports_granularity`, `group_imports`)
+# are intentionally omitted — CI and `rust-toolchain.toml` stay on stable.
+edition = "2024"
+style_edition = "2024"
+max_width = 100
+hard_tabs = false
+tab_spaces = 4
+reorder_imports = true
+use_field_init_shorthand = true
+use_try_shorthand = true


### PR DESCRIPTION
## Summary
Commit formatter/clippy policy in-tree instead of only in CI: `rustfmt.toml`, workspace Clippy groups, rust-analyzer import matching, a `profiling` profile, faster `dev` dependency compiles, and a thin `cargo-deny` licenses/sources gate.

Closes #73

## Test plan
- [ ] CI Lint & Budgets / Test (linux) on this PR
- [ ] `cargo fmt --all --check`
- [ ] `cargo clippy --workspace --all-targets --features whycodes-storage/bundled -- -D warnings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)