### PR TITLE
fix(lsp): wait for initialized before extras fake-server exit

### DIFF
--- a/crates/lsp/src/client.rs
+++ b/crates/lsp/src/client.rs
@@ -404,6 +404,13 @@ diag = {
     "message": "boom",
     "source": "fake",
 }
+# Modes that emit extra stdout after initialize. Stay alive until the
+# client sends `initialized`; exiting earlier races into Broken pipe on Linux.
+extras = {
+    "diag_notify", "bad_json", "response_notify", "empty_line",
+    "other_notify", "diag_no_params", "bg_noise", "unparsed_diag",
+    "partial_line", "trunc_body", "trunc_sep", "bg_bad_len",
+}
 
 while True:
     msg = read_msg()
@@ -432,11 +439,6 @@ while True:
             import time
             time.sleep(2)
         write_msg({"jsonrpc": "2.0", "id": mid, "result": {"capabilities": {}}})
-        extras = {
-            "diag_notify", "bad_json", "response_notify", "empty_line",
-            "other_notify", "diag_no_params", "bg_noise", "unparsed_diag",
-            "partial_line", "trunc_body", "trunc_sep", "bg_bad_len",
-        }
         if mode == "diag_notify":
             write_msg({
                 "jsonrpc": "2.0",
@@ -487,13 +489,13 @@ while True:
         if mode == "trunc_sep":
             sys.stdout.buffer.write(b"Content-Length: 2\r\n")
             sys.stdout.buffer.flush()
-        if mode in extras:
-            break
         continue
     if method == "initialized" or method == "textDocument/didOpen":
         if method == "initialized" and mode == "init_then_eof":
             break
         if method == "textDocument/didOpen" and mode == "fail_after_open":
+            break
+        if method == "initialized" and mode in extras:
             break
         continue
     if mid is None:

--- a/crates/server/src/http_tests.rs
+++ b/crates/server/src/http_tests.rs
@@ -49,14 +49,19 @@ impl IsolatedHome {
     pub(crate) fn set_prev(&mut self, prev: Option<std::ffi::OsString>) {
         self.prev = prev;
     }
-}
 
-impl Drop for IsolatedHome {
-    fn drop(&mut self) {
+    /// Restore `WHYCODES_HOME` while still holding `ENV_LOCK`.
+    pub(crate) fn restore_env(&self) {
         match &self.prev {
             Some(v) => unsafe { std::env::set_var("WHYCODES_HOME", v) },
             None => unsafe { std::env::remove_var("WHYCODES_HOME") },
         }
+    }
+}
+
+impl Drop for IsolatedHome {
+    fn drop(&mut self) {
+        self.restore_env();
     }
 }
 
@@ -802,13 +807,14 @@ fn isolated_home_restores_previous_env() {
     let sentinel = std::ffi::OsString::from("/tmp/whycodes-prev-home");
     let mut home = IsolatedHome::new();
     home.set_prev(Some(sentinel.clone()));
-    drop(home);
+    home.restore_env();
     assert_eq!(
         std::env::var_os("WHYCODES_HOME").as_deref(),
         Some(sentinel.as_os_str())
     );
-    // Do not leak the sentinel into later tests.
+    // Drop must not leak the sentinel once the lock is released.
     unsafe { std::env::remove_var("WHYCODES_HOME") };
+    home.set_prev(None);
 }
 
 #[test]

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -144,6 +144,28 @@ Only bump a budget in the **same commit**, and say why. If the count is *below* 
 
 ## Log
 
+### 2026-09-10 — Fake LSP extras modes raced `initialized` into Broken pipe
+
+**Symptom:** CI `Test (linux)` failed after ~4m at
+`client::tests::background_reader_handles_malformed_and_other_messages`
+(`crates/lsp/src/client_tests.rs`) with
+`initialized notification failed: Broken pipe (os error 32)`.
+
+**Root cause:** The in-process fake LSP (`FAKE_LSP_PY`) treated extras
+modes (`bad_json`, `diag_notify`, `trunc_*`, …) as “emit extra stdout
+then `break`” right after the `initialize` *response*. The client still
+sends `initialized` next. On Linux that write often hits a closed stdin
+and the whole start handshake unwraps. Windows is usually slower to
+reap the child, so the same test can pass locally.
+
+**Fix:** Keep extras modes alive until `initialized` arrives, then
+exit. `close_stdin` / `die_after_init` stay the explicit pipe-fail
+paths.
+
+**Prevention:** Fake servers that the client still talks to after
+`initialize` must not close stdin/stdout until that notification is
+read (or the test is specifically asserting Broken pipe).
+
 ### 2026-09-07 — Chat scroll paint panics (`index outside of buffer`)
 
 **Symptom:** Wheel / trackpad scroll in a session paints the recovered

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -144,6 +144,23 @@ Only bump a budget in the **same commit**, and say why. If the count is *below* 
 
 ## Log
 
+### 2026-09-10 — `IsolatedHome` restore asserted after dropping `ENV_LOCK`
+
+**Symptom:** CI `Test (linux)` failed
+`http_tests::isolated_home_restores_previous_env`
+(`crates/server/src/http_tests.rs`) with
+`left: Some("/tmp/.tmp…")` / `right: Some("/tmp/whycodes-prev-home")`.
+
+**Root cause:** The test `drop(home)` then reads `WHYCODES_HOME`. Drop
+restores the sentinel *and* releases `ENV_LOCK`. A sibling IsolatedHome
+can then overwrite the env before the assertion.
+
+**Fix:** Call `restore_env()` while the guard is still held, assert,
+then `set_prev(None)` so Drop does not leak the sentinel.
+
+**Prevention:** Never sample process env after releasing a lock that
+serializes that env. Assert under the same guard that wrote it.
+
 ### 2026-09-10 — Fake LSP extras modes raced `initialized` into Broken pipe
 
 **Symptom:** CI `Test (linux)` failed after ~4m at


### PR DESCRIPTION
## Why

CI `Test (linux)` on `main` (push of #77, run 34165745612) failed after ~4m:

```
client::tests::background_reader_handles_malformed_and_other_messages
initialized notification failed: Broken pipe (os error 32)
```

This is still red on `origin/main` (`66443c1`). It was **not** fixed on main.

## Cause

The in-process fake LSP treated extras modes (`bad_json`, `diag_notify`, `trunc_*`, …) as “emit extra stdout then `break`” right after the `initialize` *response*. The client still sends `initialized` next. On Linux that write often hits a closed stdin.

## Fix

Keep extras modes alive until `initialized` arrives, then exit. `close_stdin` / `die_after_init` stay the explicit pipe-fail paths.

Same change is also on `feat/lsp-config` (PR #80), but that PR currently conflicts with main, so this is the isolated hotfix.