### PR TITLE
feat: provider and model system prompts from markdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 2
+  # Three Linux jobs share one 4-vCPU host. One rustc per job keeps the
+  # pool from thrashing; wall-clock is then coverage, not a 12-minute kill.
+  CARGO_BUILD_JOBS: 1
 
 # One pipeline per PR / branch. A new push cancels the previous run so the
 # runner pool is not stuck on stale jobs.
@@ -140,7 +143,7 @@ jobs:
   test:
     name: Test (linux)
     runs-on: self-hosted
-    timeout-minutes: 12
+    timeout-minutes: 25
     # Independent of coverage/build so a runner pool can run them together.
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
@@ -159,7 +162,7 @@ jobs:
   coverage:
     name: Coverage (line floor)
     runs-on: self-hosted
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
@@ -186,7 +189,7 @@ jobs:
   build:
     name: Build (linux)
     runs-on: self-hosted
-    timeout-minutes: 12
+    timeout-minutes: 20
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,9 +23,6 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 2
-  # Three Linux jobs share one 4-vCPU host. One rustc per job keeps the
-  # pool from thrashing; wall-clock is then coverage, not a 12-minute kill.
-  CARGO_BUILD_JOBS: 1
 
 # One pipeline per PR / branch. A new push cancels the previous run so the
 # runner pool is not stuck on stale jobs.
@@ -48,7 +45,7 @@ jobs:
   lint:
     name: Lint & Budgets
     runs-on: self-hosted
-    timeout-minutes: 10
+    timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v7
@@ -146,6 +143,9 @@ jobs:
     timeout-minutes: 25
     # Independent of coverage/build so a runner pool can run them together.
     needs: lint
+    env:
+      # One rustc per parallel job on the shared 4-vCPU host.
+      CARGO_BUILD_JOBS: 1
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - uses: actions/checkout@v7
@@ -164,6 +164,8 @@ jobs:
     runs-on: self-hosted
     timeout-minutes: 30
     needs: lint
+    env:
+      CARGO_BUILD_JOBS: 1
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - uses: actions/checkout@v7
@@ -190,6 +192,8 @@ jobs:
     name: Build (linux)
     runs-on: self-hosted
     timeout-minutes: 20
+    env:
+      CARGO_BUILD_JOBS: 1
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,20 +24,23 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 2
 
-# One pipeline per PR / branch. The repo has a single self-hosted Linux runner;
-# without this, every push to main queues jobs behind the previous run.
+# One pipeline per PR / branch. A new push cancels the previous run so the
+# runner pool is not stuck on stale jobs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# Linux jobs run on the repo's self-hosted runner (no GitHub-hosted minutes).
-# Fork pull requests never do: untrusted workflow + checkout on that machine
-# is a takeover. Same-repo PRs and pushes to main still run here.
+# Linux jobs run on the repo's self-hosted runner pool (no GitHub-hosted
+# minutes). lint is the cheap gate; test, coverage, and build then run in
+# parallel when more than one runner is online. Fork pull requests never do:
+# untrusted workflow + checkout on those machines is a takeover. Same-repo
+# PRs and pushes to main still run here.
 # Job-level `if` cannot use `matrix` — multi-OS is a separate optional job set
 # on GitHub-hosted runners (set repo variable CI_MULTI_OS=true).
 #
 # `github.event.pull_request.head.repo.full_name` is empty on push, so the
-# first clause keeps those jobs.
+# first clause keeps those jobs. Each runner process must keep its own
+# `_work` directory so parallel cargo jobs do not share `target/`.
 jobs:
   lint:
     name: Lint & Budgets
@@ -53,7 +56,7 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
         with:
-          # Shared key keeps lint/test/build/coverage on same cache on the single runner.
+          # Shared key so every Linux job restores the same cargo cache.
           shared-key: whycodes-ci
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@v7
@@ -138,6 +141,7 @@ jobs:
     name: Test (linux)
     runs-on: self-hosted
     timeout-minutes: 12
+    # Independent of coverage/build so a runner pool can run them together.
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
@@ -155,7 +159,7 @@ jobs:
   coverage:
     name: Coverage (line floor)
     runs-on: self-hosted
-    timeout-minutes: 10
+    timeout-minutes: 15
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,8 @@ jobs:
       # checked by Python instead of 12 separate `cargo llvm-cov -p` re-runs.
       # Wrapper flags live in scripts/coverage.sh (same as local `scripts/coverage.sh`).
       - name: Measure coverage
-        run: COVERAGE_FEATURES=whycodes-storage/bundled scripts/coverage.sh
+        # Unique path so two coverage jobs on one host cannot clobber /tmp/cov.json.
+        run: COVERAGE_FEATURES=whycodes-storage/bundled REPORT_JSON="$RUNNER_TEMP/cov.json" scripts/coverage.sh
 
   build:
     name: Build (linux)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,7 +50,7 @@ default group. License/source policy is `deny.toml`; advisory ignores stay in
 
 Dev builds use system SQLite (`pkg-config sqlite3`). CI and release enable
 `whycodes-storage/bundled` / `whycodes-cli/bundled-sqlite` so the self-hosted
-runner and shipped binaries do not need `libsqlite3-dev`. Locally, omit the
+runners and shipped binaries do not need `libsqlite3-dev`. Locally, omit the
 feature if `sqlite3` is already installed.
 
 If you changed `crates/protocol/src/sdk.rs` or the TypeScript client, also
@@ -77,11 +77,12 @@ Things to know about CI:
 - Internal crate edges are allowlisted in
   `scripts/dependency_boundaries.json`. Adding an edge is a deliberate
   architectural decision — see [docs/architecture.md](docs/architecture.md).
-- Linux CI runs on a **self-hosted** runner, so pull requests from forks are
-  skipped there on purpose (untrusted workflow + checkout on that machine).
-  Open the PR anyway; a maintainer will run the suite from a same-repo
-  branch. A new push to the same PR or to `main` cancels the previous CI run
-  so the single runner is not stuck on stale jobs.
+- Linux CI runs on a **self-hosted** runner pool, so pull requests from forks
+  are skipped there on purpose (untrusted workflow + checkout on those
+  machines). Open the PR anyway; a maintainer will run the suite from a
+  same-repo branch. A new push to the same PR or to `main` cancels the
+  previous CI run so the pool is not stuck on stale jobs. After lint, Test /
+  Coverage / Build run in parallel across whatever runners are online.
 
 ## Conventions
 

--- a/crates/agent/src/agent/dispatch.rs
+++ b/crates/agent/src/agent/dispatch.rs
@@ -770,6 +770,7 @@ impl Agent {
         let hub = hub.clone();
         let question_prompter = Arc::clone(&self.question_prompter);
         let approval_mode = self.approval_mode;
+        let overlays = self.system_prompt_overlays.clone();
 
         let mut handles = Vec::with_capacity(specs.len());
 
@@ -796,6 +797,7 @@ impl Agent {
             let panel = panel.clone();
             let hub = hub.clone();
             let question_prompter = Arc::clone(&question_prompter);
+            let overlays = overlays.clone();
             hub.ensure(&worker_id);
 
             handles.push(tokio::spawn(async move {
@@ -870,7 +872,12 @@ impl Agent {
                             allowed_paths: None,
                             rules: Default::default(),
                         },
-                        Agent::system_prompt_for(&spec.subagent_type),
+                        Agent::with_prompt_overlays(
+                            &Agent::system_prompt_for(&spec.subagent_type),
+                            &overlays,
+                            pn.as_ref(),
+                            m.as_ref(),
+                        ),
                     ),
                     _ => {
                         let mut perm = parent_permission;
@@ -881,7 +888,15 @@ impl Agent {
                             }
                         }
                         perm.denied_tools = Some(denied);
-                        (perm, Agent::system_prompt_for("general"))
+                        (
+                            perm,
+                            Agent::with_prompt_overlays(
+                                &Agent::system_prompt_for("general"),
+                                &overlays,
+                                pn.as_ref(),
+                                m.as_ref(),
+                            ),
+                        )
                     }
                 };
 
@@ -1135,6 +1150,8 @@ impl Agent {
             .unwrap_or(15) as usize;
 
         // Permission profile per OpenCode subagent type
+        let (worker_provider, worker_model) =
+            crate::routing::resolve_worker_model(provider_name, model, self.model_smol.as_deref());
         let (permission, system_prompt) = match subagent_type {
             "explore" | "scout" => (
                 PermissionSet {
@@ -1164,7 +1181,12 @@ impl Agent {
                     allowed_paths: None,
                     rules: Default::default(),
                 },
-                Self::system_prompt_for(subagent_type),
+                Self::with_prompt_overlays(
+                    &Self::system_prompt_for(subagent_type),
+                    &self.system_prompt_overlays,
+                    &worker_provider,
+                    &worker_model,
+                ),
             ),
             _ => {
                 // general: full tools except todo / nested swarm (OpenCode default + safety)
@@ -1176,7 +1198,15 @@ impl Agent {
                     }
                 }
                 perm.denied_tools = Some(denied);
-                (perm, Self::system_prompt_for("general"))
+                (
+                    perm,
+                    Self::with_prompt_overlays(
+                        &Self::system_prompt_for("general"),
+                        &self.system_prompt_overlays,
+                        &worker_provider,
+                        &worker_model,
+                    ),
+                )
             }
         };
 
@@ -1222,8 +1252,6 @@ impl Agent {
             },
         );
 
-        let (worker_provider, worker_model) =
-            crate::routing::resolve_worker_model(provider_name, model, self.model_smol.as_deref());
         let result = runner
             .run(task, &worker_provider, &worker_model, api_key)
             .await;

--- a/crates/agent/src/agent/mod.rs
+++ b/crates/agent/src/agent/mod.rs
@@ -25,7 +25,7 @@ use crate::events::{EventSink, TurnEvent};
 use crate::permission::{PermissionPrompter, default_prompter};
 use crate::question::{QuestionPrompter, default_question_prompter};
 use whycodes_command_risk::RiskThreshold;
-use whycodes_config::{HookConfig, NotifyConfig};
+use whycodes_config::{HookConfig, NotifyConfig, SystemPromptOverlays};
 
 pub const DEFAULT_SYSTEM_PROMPT: &str = include_str!("../../prompts/build.txt");
 
@@ -103,6 +103,12 @@ pub struct Agent {
     swarm_hub: Option<whycodes_core::SwarmHub>,
     /// `[lsp]` overlay from config (empty = built-in auto-detect).
     lsp_overlay: whycodes_tools::LspSettings,
+    /// Provider/model extras from `prompts/*.md`.
+    system_prompt_overlays: SystemPromptOverlays,
+    /// Active provider id for overlay lookup (`/models`, session route).
+    route_provider: String,
+    /// Active model id for overlay lookup.
+    route_model: String,
 }
 
 /// Recover from a poisoned mutex instead of aborting (`panic = "abort"` in release).
@@ -346,6 +352,9 @@ impl Agent {
             session_claims: None,
             swarm_hub: None,
             lsp_overlay: whycodes_tools::LspSettings::default(),
+            system_prompt_overlays: SystemPromptOverlays::default(),
+            route_provider: String::new(),
+            route_model: String::new(),
         }
     }
 
@@ -422,6 +431,22 @@ impl Agent {
     /// Session-level approval overlay (`auto` / `important` / `manual`).
     pub fn set_approval_mode(&mut self, mode: ApprovalMode) {
         self.approval_mode = mode;
+    }
+
+    /// Bind the active provider/model so [`Self::system_prompt`] can append
+    /// matching `prompts/*.md` extras.
+    pub fn set_route(&mut self, provider: &str, model: &str) {
+        self.route_provider = provider.to_string();
+        self.route_model = model.to_string();
+    }
+
+    pub fn route(&self) -> (&str, &str) {
+        (&self.route_provider, &self.route_model)
+    }
+
+    /// Replace loaded `prompts/*.md` extras (TUI hydrate after first paint).
+    pub fn set_system_prompt_overlays(&mut self, overlays: SystemPromptOverlays) {
+        self.system_prompt_overlays = overlays;
     }
 
     /// Current approval overlay.
@@ -510,6 +535,7 @@ impl Agent {
         // agent switches / re-config.
         self.background.set_max_jobs(self.max_background_jobs);
         self.lsp_overlay = lsp_overlay_from_config(&config.lsp);
+        self.system_prompt_overlays = config.system_prompt_overlays.clone();
         let sandbox_desc = whycodes_sandbox::describe_backend(&self.sandbox);
         let network_allow = self.network.allowlist.len();
         let network_deny = self.network.denylist.len();
@@ -729,7 +755,43 @@ impl Agent {
             .system_prompt
             .clone()
             .unwrap_or_else(|| Self::system_prompt_for(&self.info.name));
-        Self::with_runtime_context(&base)
+        Self::with_runtime_context(&Self::with_prompt_overlays(
+            &base,
+            &self.system_prompt_overlays,
+            &self.route_provider,
+            &self.route_model,
+        ))
+    }
+
+    /// Role prompt plus provider/model extras from `prompts/*.md` (no runtime).
+    pub fn system_prompt_for_route(&self, provider: &str, model: &str) -> String {
+        let base = self
+            .info
+            .system_prompt
+            .clone()
+            .unwrap_or_else(|| Self::system_prompt_for(&self.info.name));
+        Self::with_prompt_overlays(&base, &self.system_prompt_overlays, provider, model)
+    }
+
+    /// Append provider then model extras. Empty overlay is a no-op.
+    pub fn with_prompt_overlays(
+        system_prompt: &str,
+        overlays: &SystemPromptOverlays,
+        provider: &str,
+        model: &str,
+    ) -> String {
+        let sections = overlays.sections(provider, model);
+        if sections.is_empty() {
+            return system_prompt.to_string();
+        }
+        let mut out = String::from(system_prompt);
+        for (label, body) in sections {
+            out.push_str("\n\n# ");
+            out.push_str(&label);
+            out.push_str("\n\n");
+            out.push_str(&body);
+        }
+        out
     }
 
     /// Get the system prompt for a named agent.

--- a/crates/agent/src/agent/mod_tests.rs
+++ b/crates/agent/src/agent/mod_tests.rs
@@ -204,6 +204,52 @@ fn system_prompt_for_known_and_unknown_agents() {
 }
 
 #[test]
+fn prompt_overlays_append_provider_then_model() {
+    let mut overlays = whycodes_config::SystemPromptOverlays::default();
+    overlays.providers.insert("xai".into(), "be terse".into());
+    overlays
+        .models
+        .insert("xai/grok-4.6".into(), "use tools".into());
+    let out = Agent::with_prompt_overlays("base", &overlays, "XAI", "grok-4.6");
+    assert!(out.starts_with("base"), "{out}");
+    assert!(out.contains("# Provider instructions (xai)"), "{out}");
+    assert!(out.contains("be terse"), "{out}");
+    assert!(out.contains("# Model instructions (grok-4.6)"), "{out}");
+    assert!(out.contains("use tools"), "{out}");
+    assert_eq!(
+        Agent::with_prompt_overlays("base", &overlays, "", ""),
+        "base"
+    );
+}
+
+#[test]
+fn system_prompt_includes_route_overlays() {
+    let mut agent = Agent::new(whycodes_core::types::AgentInfo {
+        name: "build".into(),
+        description: String::new(),
+        mode: whycodes_core::types::AgentMode::Primary,
+        permission: whycodes_core::types::PermissionSet::default(),
+        model: None,
+        system_prompt: Some("role".into()),
+        temperature: None,
+        top_p: None,
+    });
+    let mut cfg = whycodes_config::Config::default();
+    cfg.system_prompt_overlays
+        .providers
+        .insert("xai".into(), "xai extra".into());
+    agent.apply_config(&cfg);
+    agent.set_route("xai", "grok-4.6");
+    let prompt = agent.system_prompt();
+    assert!(prompt.contains("role"), "{prompt}");
+    assert!(prompt.contains("xai extra"), "{prompt}");
+    assert!(prompt.contains("Today's date:"), "{prompt}");
+    let routed = agent.system_prompt_for_route("xai", "grok-4.6");
+    assert!(routed.contains("xai extra"), "{routed}");
+    assert!(!routed.contains("Today's date:"), "{routed}");
+}
+
+#[test]
 fn runtime_context_is_idempotent_and_append_only() {
     let base = "You are an agent.";
     let once = Agent::with_runtime_context(base);

--- a/crates/cli/src/cmd/helpers.rs
+++ b/crates/cli/src/cmd/helpers.rs
@@ -363,7 +363,8 @@ pub(crate) fn refresh_session_memory(
     config: &Config,
     query: Option<&str>,
 ) {
-    let base = Agent::with_agents_md(&agent.system_prompt(), project_dir);
+    let (provider, model) = agent.route();
+    let base = Agent::with_agents_md(&agent.system_prompt_for_route(provider, model), project_dir);
     session.set_system_prompt(&with_project_memory(&base, project_dir, config, query));
 }
 
@@ -383,6 +384,8 @@ pub(crate) fn switch_agent(
     name: &str,
     config: &Config,
     project_dir: &std::path::Path,
+    provider: &str,
+    model: &str,
 ) -> anyhow::Result<(String, Agent, String)> {
     let name = name.trim();
     let info = config.get_agent(name).cloned().ok_or_else(|| {
@@ -391,17 +394,14 @@ pub(crate) fn switch_agent(
             name
         )
     })?;
-    let base = info
-        .system_prompt
-        .clone()
-        .unwrap_or_else(|| Agent::system_prompt_for(name));
+    let mut agent = Agent::new(info).with_config(config);
+    agent.set_route(provider, model);
     let prompt = with_project_memory(
-        &Agent::with_agents_md(&base, project_dir),
+        &Agent::with_agents_md(&agent.system_prompt_for_route(provider, model), project_dir),
         project_dir,
         config,
         None,
     );
-    let agent = Agent::new(info);
     Ok((name.to_string(), agent, prompt))
 }
 

--- a/crates/cli/src/cmd/run.rs
+++ b/crates/cli/src/cmd/run.rs
@@ -561,17 +561,6 @@ pub(crate) async fn cmd_run(
         info.permission = config.effective_permission(&info.permission);
         info
     };
-    let base_prompt = agent_info
-        .system_prompt
-        .clone()
-        .unwrap_or_else(|| Agent::system_prompt_for(&agent_name));
-    let system_prompt = with_project_memory(
-        &Agent::with_agents_md(&base_prompt, &project_dir),
-        &project_dir,
-        &config,
-        None,
-    );
-
     // Wall clock for the Cline-style exit summary (process open → quit).
     let session_started = std::time::Instant::now();
 
@@ -585,7 +574,17 @@ pub(crate) async fn cmd_run(
         .with_file_index(file_index)
         .with_mcp(&config)
         .await;
+    agent.set_route(&provider, &model);
     maybe_inject_test_llm(&mut agent, &provider);
+    let system_prompt = with_project_memory(
+        &Agent::with_agents_md(
+            &agent.system_prompt_for_route(&provider, &model),
+            &project_dir,
+        ),
+        &project_dir,
+        &config,
+        None,
+    );
     let mut session = whycodes_session::session::Session::new(project_dir.clone(), system_prompt);
     maybe_session_auto_index(&project_dir, &config);
     let mut history = whycodes_session::SessionHistory::new();
@@ -793,7 +792,10 @@ pub(crate) async fn cmd_run(
                     session = whycodes_session::session::Session::new(
                         project_dir.clone(),
                         with_project_memory(
-                            &Agent::with_agents_md(&agent.system_prompt(), &project_dir),
+                            &Agent::with_agents_md(
+                                &agent.system_prompt_for_route(&provider, &model),
+                                &project_dir,
+                            ),
                             &project_dir,
                             &config,
                             None,
@@ -861,7 +863,7 @@ pub(crate) async fn cmd_run(
                     // Reload system prompt with new AGENTS.md + memory
                     session.set_system_prompt(&with_project_memory(
                         &Agent::with_agents_md(
-                            &Agent::system_prompt_for(&agent_name),
+                            &agent.system_prompt_for_route(&provider, &model),
                             &project_dir,
                         ),
                         &project_dir,
@@ -1049,11 +1051,27 @@ pub(crate) async fn cmd_run(
                                 provider = p;
                                 model = m;
                                 api_key = get_api_key(&provider, &config).await.unwrap_or_default();
+                                agent.set_route(&provider, &model);
+                                refresh_session_memory(
+                                    &mut session,
+                                    &agent,
+                                    &project_dir,
+                                    &config,
+                                    None,
+                                );
                                 println!("{}", switched_model_line(&provider, &model));
                                 maybe_inject_test_llm(&mut agent, &provider);
                             }
                             ModelsSlash::ModelOnly(m) => {
                                 model = m;
+                                agent.set_route(&provider, &model);
+                                refresh_session_memory(
+                                    &mut session,
+                                    &agent,
+                                    &project_dir,
+                                    &config,
+                                    None,
+                                );
                                 println!("{}", model_set_line(&model));
                             }
                         }
@@ -1107,7 +1125,7 @@ pub(crate) async fn cmd_run(
                         let _ = super::provider::cmd_agent(None).await;
                         println!("Current agent: {}", agent_name.cyan());
                     } else {
-                        match switch_agent(rest, &config, &project_dir) {
+                        match switch_agent(rest, &config, &project_dir, &provider, &model) {
                             Ok((name, new_agent, prompt)) => {
                                 agent_name = name;
                                 agent = new_agent;
@@ -1440,6 +1458,7 @@ pub(crate) async fn cmd_generate(
     if cli.no_memory {
         config.memory.enabled = false;
     }
+    config.load_command_files(&project_dir);
     let provider = resolve_provider(cli, &config);
     let model = resolve_model(cli, &config);
     let agent_name = resolve_agent(cli, &config);
@@ -1485,17 +1504,7 @@ pub(crate) async fn cmd_generate(
 
     let mut agent_info = agent_info_for(cli, &config);
     agent_info.permission = config.effective_permission(&agent_info.permission);
-    let base_prompt = agent_info
-        .system_prompt
-        .clone()
-        .unwrap_or_else(|| Agent::system_prompt_for(&agent_name));
     let expanded = expand_user_input(prompt, &project_dir);
-    let system_prompt = with_project_memory(
-        &Agent::with_agents_md(&base_prompt, &project_dir),
-        &project_dir,
-        &config,
-        Some(&expanded),
-    );
 
     // Structured CI formats cannot prompt on stdin; auto-approve tool asks.
     // Catastrophic shell risk still hard-blocks regardless of this.
@@ -1507,7 +1516,17 @@ pub(crate) async fn cmd_generate(
         .with_file_index(file_index)
         .with_mcp(&config)
         .await;
+    agent.set_route(&provider, &model);
     maybe_inject_test_llm(&mut agent, &provider);
+    let system_prompt = with_project_memory(
+        &Agent::with_agents_md(
+            &agent.system_prompt_for_route(&provider, &model),
+            &project_dir,
+        ),
+        &project_dir,
+        &config,
+        Some(&expanded),
+    );
     if format.is_structured() {
         agent = agent
             .with_permission_prompter(Arc::new(AutoApprovePrompter))
@@ -1661,17 +1680,7 @@ pub(crate) async fn run_one_parallel_turn(
 ) -> bool {
     let started = std::time::Instant::now();
 
-    let base_prompt = agent_info
-        .system_prompt
-        .clone()
-        .unwrap_or_else(|| Agent::system_prompt_for(agent_name));
     let expanded = expand_user_input(prompt, project_dir);
-    let system_prompt = with_project_memory(
-        &Agent::with_agents_md(&base_prompt, project_dir),
-        project_dir,
-        config,
-        Some(&expanded),
-    );
 
     let file_index = whycodes_index::WorkspaceIndex::start(
         whycodes_index::WorkspaceIndex::project_roots(project_dir),
@@ -1681,7 +1690,14 @@ pub(crate) async fn run_one_parallel_turn(
         .with_file_index(file_index)
         .with_mcp(config)
         .await;
+    agent.set_route(provider, model);
     maybe_inject_test_llm(&mut agent, provider);
+    let system_prompt = with_project_memory(
+        &Agent::with_agents_md(&agent.system_prompt_for_route(provider, model), project_dir),
+        project_dir,
+        config,
+        Some(&expanded),
+    );
     if structured {
         agent = agent
             .with_permission_prompter(Arc::new(AutoApprovePrompter))

--- a/crates/cli/src/cmd/serve.rs
+++ b/crates/cli/src/cmd/serve.rs
@@ -105,7 +105,8 @@ pub(crate) async fn cmd_serve(port: u16, no_takeover: bool) -> anyhow::Result<()
     println!("{}", serve_start_line(port));
     println!("  project: {}", project_dir.display());
 
-    let config = Config::load()?;
+    let mut config = Config::load()?;
+    config.load_command_files(&project_dir);
     let agent_info = config
         .default_agent()
         .cloned()
@@ -142,7 +143,7 @@ pub(crate) async fn cmd_serve(port: u16, no_takeover: bool) -> anyhow::Result<()
         None
     };
     question_prompter.notify = Some(whycodes_agent::notify::handle_from_config(&config.notify));
-    let agent = Agent::new(agent_info)
+    let mut agent = Agent::new(agent_info)
         .with_config(&config)
         .with_permission_prompter(Arc::new(whycodes_server::perm::ServePrompter {
             hub: Arc::clone(&perm),
@@ -152,6 +153,8 @@ pub(crate) async fn cmd_serve(port: u16, no_takeover: bool) -> anyhow::Result<()
         .with_plugins(Some(&project_dir))
         .with_mcp(&config)
         .await;
+    let (provider, model) = whycodes_server::routes::default_provider_model(&config);
+    agent.set_route(&provider, &model);
 
     let state = whycodes_server::AppState {
         agent: Arc::new(agent),

--- a/crates/cli/src/tests.rs
+++ b/crates/cli/src/tests.rs
@@ -1264,10 +1264,11 @@ fn print_slash_help_and_switch_agent() {
     print_slash_help();
     let config = Config::default();
     let dir = tempfile::tempdir().unwrap();
-    let (name, _agent, prompt) = switch_agent("build", &config, dir.path()).unwrap();
+    let (name, _agent, prompt) =
+        switch_agent("build", &config, dir.path(), "xai", "grok-4.6").unwrap();
     assert_eq!(name, "build");
     assert!(!prompt.is_empty());
-    assert!(switch_agent("nope", &config, dir.path()).is_err());
+    assert!(switch_agent("nope", &config, dir.path(), "xai", "grok-4.6").is_err());
 }
 
 #[test]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -17,7 +17,8 @@ pub use types::{
     CustomToolConfig, GeneralConfig, HookConfig, HookEvent, LspConfig, LspServerConfig,
     MagicKeywordsConfig, McpServerConfig, McpTransportKind, MemoryConfig, NotifyConfig,
     NotifyEvent, QuestionToolConfig, RuntimeLspServer, SecurityConfig, SessionConfig,
-    StreamRuleConfig, SwarmConfig, ToolsConfig, TuiConfig, is_discord_webhook_url,
+    StreamRuleConfig, SwarmConfig, SystemPromptOverlays, ToolsConfig, TuiConfig,
+    is_discord_webhook_url,
 };
 
 #[cfg(test)]

--- a/crates/config/src/load.rs
+++ b/crates/config/src/load.rs
@@ -4,8 +4,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use crate::types::{
-    CONFIG_SCHEMA_VERSION, CommandConfig, Config, CustomCommandConfig, nonempty_opt,
-    parse_notify_on_csv,
+    CONFIG_SCHEMA_VERSION, CommandConfig, Config, CustomCommandConfig, SystemPromptOverlays,
+    nonempty_opt, overlay_key, parse_notify_on_csv,
 };
 use whycodes_core::network;
 use whycodes_core::types::{AgentInfo, ModelConfig, ProviderConfig};
@@ -345,6 +345,22 @@ impl Config {
         );
         // Built-ins last only for missing keys — user/project markdown wins.
         self.ensure_builtin_prompt_commands();
+        self.load_prompt_files(project_dir);
+    }
+
+    /// Load provider/model system-prompt extras from markdown:
+    /// - global: `~/.config/.../prompts/`
+    /// - project: `<project>/.whycodes/prompts/` (wins on the same key)
+    pub fn load_prompt_files(&mut self, project_dir: &Path) {
+        if let Ok(global_dir) = Self::default_path()
+            && let Some(parent) = global_dir.parent()
+        {
+            load_prompt_overlays(&mut self.system_prompt_overlays, &parent.join("prompts"));
+        }
+        load_prompt_overlays(
+            &mut self.system_prompt_overlays,
+            &whycodes_core::project_dir(project_dir).join("prompts"),
+        );
     }
 
     /// Claude Code–style PromptCommands: fixed prompts that kick a turn.
@@ -424,6 +440,88 @@ User notes: $ARGUMENTS"#
             },
         ),
     ]
+}
+
+fn load_prompt_overlays(into: &mut SystemPromptOverlays, dir: &Path) {
+    load_prompt_overlays_at(into, dir, None);
+}
+
+fn load_prompt_overlays_at(into: &mut SystemPromptOverlays, dir: &Path, provider: Option<&str>) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_missing_dir) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if provider.is_some() {
+                continue;
+            }
+            let Some(name) = path.file_name().and_then(|s| s.to_str()) else {
+                continue;
+            };
+            if name.eq_ignore_ascii_case("models") {
+                load_model_overlay_dir(into, &path);
+            } else {
+                load_prompt_overlays_at(into, &path, Some(name));
+            }
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Some(body) = read_overlay_markdown(&path) else {
+            continue;
+        };
+        if let Some(p) = provider {
+            into.models
+                .insert(format!("{}/{}", overlay_key(p), overlay_key(stem)), body);
+        } else {
+            into.providers.insert(overlay_key(stem), body);
+        }
+    }
+}
+
+fn load_model_overlay_dir(into: &mut SystemPromptOverlays, dir: &Path) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_missing_dir) => return,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            continue;
+        }
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Some(body) = read_overlay_markdown(&path) else {
+            continue;
+        };
+        into.models.insert(overlay_key(stem), body);
+    }
+}
+
+fn read_overlay_markdown(path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let body = strip_overlay_frontmatter(&content);
+    if body.is_empty() { None } else { Some(body) }
+}
+
+fn strip_overlay_frontmatter(content: &str) -> String {
+    let trimmed = content.trim();
+    if let Some(rest) = trimmed.strip_prefix("---")
+        && let Some((_, body)) = rest.split_once("---")
+    {
+        return body.trim().to_string();
+    }
+    trimmed.to_string()
 }
 
 fn load_commands_from_dir(into: &mut HashMap<String, CustomCommandConfig>, dir: &Path) {

--- a/crates/config/src/load.rs
+++ b/crates/config/src/load.rs
@@ -776,4 +776,71 @@ mod tests {
 
         assert!(cfg.get_command_config("missing").is_none());
     }
+
+    #[test]
+    fn prompt_overlay_loader_covers_missing_and_junk() {
+        let dir = tempfile::tempdir().unwrap();
+        let missing = dir.path().join("no-such-prompts");
+        let mut empty = SystemPromptOverlays::default();
+        load_prompt_overlays(&mut empty, &missing);
+        load_model_overlay_dir(&mut empty, &missing);
+        assert!(empty.is_empty());
+        assert!(read_overlay_markdown(&missing).is_none());
+        assert!(read_overlay_markdown(dir.path()).is_none());
+
+        let models = dir.path().join("models");
+        std::fs::create_dir_all(models.join("nested")).unwrap();
+        std::fs::write(models.join("skip.txt"), "ignored").unwrap();
+        std::fs::write(models.join("empty.md"), "  \n").unwrap();
+        std::fs::write(models.join("ok.md"), "bare model extra").unwrap();
+        let mut loaded = SystemPromptOverlays::default();
+        load_model_overlay_dir(&mut loaded, &models);
+        assert_eq!(
+            loaded.models.get("ok").map(String::as_str),
+            Some("bare model extra")
+        );
+        assert!(!loaded.models.contains_key("skip"));
+        assert!(!loaded.models.contains_key("empty"));
+        assert!(!loaded.models.contains_key("nested"));
+
+        std::fs::write(dir.path().join("notes.txt"), "not markdown").unwrap();
+        let mut mixed = SystemPromptOverlays::default();
+        load_prompt_overlays(&mut mixed, dir.path());
+        assert_eq!(
+            mixed.models.get("ok").map(String::as_str),
+            Some("bare model extra")
+        );
+
+        let provider_dir = dir.path().join("xai");
+        std::fs::create_dir_all(provider_dir.join("nested")).unwrap();
+        std::fs::write(provider_dir.join("nested/skip.md"), "nope").unwrap();
+        std::fs::write(provider_dir.join("notes.txt"), "ignored").unwrap();
+        let mut under_provider = SystemPromptOverlays::default();
+        load_prompt_overlays_at(&mut under_provider, &provider_dir, Some("xai"));
+        assert!(under_provider.models.is_empty());
+        assert!(under_provider.providers.is_empty());
+    }
+
+    /// `file_name` / `file_stem` `to_str()` is `None` for non-UTF-8 paths (Linux CI).
+    #[cfg(unix)]
+    #[test]
+    fn prompt_overlay_skips_non_utf8_names() {
+        use std::os::unix::ffi::OsStrExt;
+        let dir = tempfile::tempdir().unwrap();
+        let bad_dir = dir.path().join(std::ffi::OsStr::from_bytes(b"bad\xffdir"));
+        std::fs::create_dir(&bad_dir).unwrap();
+        std::fs::write(
+            dir.path().join(std::ffi::OsStr::from_bytes(b"bad\xff.md")),
+            "x",
+        )
+        .unwrap();
+        let models = dir.path().join("models");
+        std::fs::create_dir(&models).unwrap();
+        std::fs::write(models.join(std::ffi::OsStr::from_bytes(b"m\xff.md")), "y").unwrap();
+
+        let mut loaded = SystemPromptOverlays::default();
+        load_prompt_overlays(&mut loaded, dir.path());
+        assert!(loaded.providers.is_empty());
+        assert!(loaded.models.is_empty());
+    }
 }

--- a/crates/config/src/merge.rs
+++ b/crates/config/src/merge.rs
@@ -372,6 +372,19 @@ impl Config {
 
         merged.notify = self.notify.merge_with(&other.notify);
 
+        for (k, v) in &other.system_prompt_overlays.providers {
+            merged
+                .system_prompt_overlays
+                .providers
+                .insert(k.clone(), v.clone());
+        }
+        for (k, v) in &other.system_prompt_overlays.models {
+            merged
+                .system_prompt_overlays
+                .models
+                .insert(k.clone(), v.clone());
+        }
+
         merged
     }
 

--- a/crates/config/src/tests.rs
+++ b/crates/config/src/tests.rs
@@ -1300,6 +1300,121 @@ fn load_command_files_loads_markdown_and_builtins() {
 }
 
 #[test]
+fn load_prompt_files_reads_provider_and_model_markdown() {
+    with_isolated_home(|home| {
+        let prompts = home.join("prompts");
+        std::fs::create_dir_all(prompts.join("xai")).unwrap();
+        std::fs::create_dir_all(prompts.join("models")).unwrap();
+        std::fs::write(prompts.join("xai.md"), "# XAI\nBe terse.").unwrap();
+        std::fs::write(
+            prompts.join("xai/grok-4.6.md"),
+            "---\nnote: ignored\n---\nGrok 4.6 extra.",
+        )
+        .unwrap();
+        std::fs::write(prompts.join("models/grok-4.md"), "generic grok-4").unwrap();
+        std::fs::write(prompts.join("skip.txt"), "ignored").unwrap();
+        std::fs::write(prompts.join("empty.md"), "  \n").unwrap();
+
+        let proj = home.join("proj");
+        let proj_prompts = proj.join(".whycodes/prompts");
+        std::fs::create_dir_all(&proj_prompts).unwrap();
+        std::fs::write(proj_prompts.join("xai.md"), "project xai wins").unwrap();
+
+        let mut cfg = Config::default();
+        cfg.load_prompt_files(&proj);
+        assert_eq!(
+            cfg.system_prompt_overlays
+                .providers
+                .get("xai")
+                .map(String::as_str),
+            Some("project xai wins")
+        );
+        assert_eq!(
+            cfg.system_prompt_overlays
+                .models
+                .get("xai/grok-4.6")
+                .map(String::as_str),
+            Some("Grok 4.6 extra.")
+        );
+        assert_eq!(
+            cfg.system_prompt_overlays
+                .models
+                .get("grok-4")
+                .map(String::as_str),
+            Some("generic grok-4")
+        );
+        assert!(!cfg.system_prompt_overlays.providers.contains_key("skip"));
+        assert!(!cfg.system_prompt_overlays.providers.contains_key("empty"));
+
+        let sections = cfg.system_prompt_overlays.sections("xai", "grok-4.6");
+        assert_eq!(sections.len(), 2);
+        assert!(sections[0].1.contains("project xai wins"));
+        assert!(sections[1].1.contains("Grok 4.6 extra."));
+
+        // Nested dirs under a provider folder are ignored; broken frontmatter
+        // still yields the body; unreadable paths are skipped.
+        std::fs::create_dir_all(prompts.join("xai/nested")).unwrap();
+        std::fs::write(prompts.join("xai/nested/skip.md"), "nope").unwrap();
+        std::fs::write(prompts.join("xai/open.md"), "---\nno close").unwrap();
+        std::fs::create_dir(prompts.join("models/dir.md")).unwrap();
+        let mut cfg2 = Config::default();
+        cfg2.load_prompt_files(&proj);
+        assert!(
+            !cfg2
+                .system_prompt_overlays
+                .models
+                .values()
+                .any(|v| v.contains("nope"))
+        );
+        assert_eq!(
+            cfg2.system_prompt_overlays
+                .models
+                .get("xai/open")
+                .map(String::as_str),
+            Some("---\nno close")
+        );
+        assert!(!cfg2.system_prompt_overlays.models.contains_key("dir"));
+    });
+}
+
+#[test]
+fn merge_overlays_project_keys_win() {
+    let mut base = Config::default();
+    base.system_prompt_overlays
+        .providers
+        .insert("xai".into(), "global".into());
+    base.system_prompt_overlays
+        .models
+        .insert("grok".into(), "g".into());
+    let mut other = Config::default();
+    other
+        .system_prompt_overlays
+        .providers
+        .insert("xai".into(), "project".into());
+    other
+        .system_prompt_overlays
+        .models
+        .insert("xai/grok".into(), "specific".into());
+    let merged = base.merge_with(&other);
+    assert_eq!(
+        merged.system_prompt_overlays.providers.get("xai").unwrap(),
+        "project"
+    );
+    assert_eq!(
+        merged.system_prompt_overlays.models.get("grok").unwrap(),
+        "g"
+    );
+    assert_eq!(
+        merged
+            .system_prompt_overlays
+            .models
+            .get("xai/grok")
+            .unwrap(),
+        "specific"
+    );
+}
+
+#[test]
 fn builtin_prompt_commands_do_not_overwrite_user() {
     let mut cfg = Config::default();
     cfg.commands.insert(

--- a/crates/config/src/types.rs
+++ b/crates/config/src/types.rs
@@ -116,6 +116,10 @@ pub struct Config {
     /// Discord / Telegram session notifications (off by default).
     #[serde(default)]
     pub notify: NotifyConfig,
+
+    /// Extra system-prompt text loaded from `prompts/*.md` (not stored in TOML).
+    #[serde(default, skip)]
+    pub system_prompt_overlays: SystemPromptOverlays,
 }
 
 /// Process-local background shell jobs and schedule/loop knobs.
@@ -761,7 +765,102 @@ impl Default for Config {
             swarm: SwarmConfig::default(),
             automation: AutomationConfig::default(),
             notify: NotifyConfig::default(),
+            system_prompt_overlays: SystemPromptOverlays::default(),
         }
+    }
+}
+
+/// Provider / model system-prompt extras loaded from markdown files.
+///
+/// File layout (global `prompts/` next to `config.toml`, project
+/// `.whycodes/prompts/` — project keys overwrite):
+///
+/// - `prompts/<provider>.md` — every model on that provider
+/// - `prompts/<provider>/<model>.md` — that provider+model
+/// - `prompts/models/<model>.md` — that model id on any provider
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SystemPromptOverlays {
+    /// Keyed by lowercase provider id (`xai`).
+    pub providers: HashMap<String, String>,
+    /// Keyed by lowercase `provider/model` or bare `model`.
+    pub models: HashMap<String, String>,
+}
+
+impl SystemPromptOverlays {
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty() && self.models.is_empty()
+    }
+
+    /// Provider body (if any) then the most specific model body.
+    ///
+    /// Model match order: `provider/model`, then bare `model`.
+    pub fn sections(&self, provider: &str, model: &str) -> Vec<(String, String)> {
+        let p = overlay_key(provider);
+        let m = overlay_key(model);
+        let mut out = Vec::new();
+        if !p.is_empty()
+            && let Some(body) = self.providers.get(&p)
+        {
+            out.push((format!("Provider instructions ({p})"), body.clone()));
+        }
+        if !m.is_empty() {
+            let body = if p.is_empty() {
+                self.models.get(&m)
+            } else {
+                self.models
+                    .get(&format!("{p}/{m}"))
+                    .or_else(|| self.models.get(&m))
+            };
+            if let Some(body) = body {
+                out.push((format!("Model instructions ({m})"), body.clone()));
+            }
+        }
+        out
+    }
+}
+
+pub(crate) fn overlay_key(raw: &str) -> String {
+    raw.trim().to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod overlay_tests {
+    use super::*;
+
+    #[test]
+    fn overlay_key_trims_and_lowercases() {
+        assert_eq!(overlay_key("  XAI "), "xai");
+        assert_eq!(overlay_key(""), "");
+    }
+
+    #[test]
+    fn sections_provider_then_specific_model() {
+        let mut o = SystemPromptOverlays::default();
+        o.providers.insert("xai".into(), "prov".into());
+        o.models.insert("xai/grok-4.6".into(), "specific".into());
+        o.models.insert("grok-4.6".into(), "generic".into());
+        let s = o.sections("XAI", "grok-4.6");
+        assert_eq!(s.len(), 2);
+        assert_eq!(s[0].0, "Provider instructions (xai)");
+        assert_eq!(s[0].1, "prov");
+        assert_eq!(s[1].0, "Model instructions (grok-4.6)");
+        assert_eq!(s[1].1, "specific");
+    }
+
+    #[test]
+    fn sections_bare_model_when_no_provider_or_specific() {
+        let mut o = SystemPromptOverlays::default();
+        o.models.insert("grok-4.6".into(), "generic".into());
+        let s = o.sections("xai", "grok-4.6");
+        assert_eq!(
+            s,
+            vec![("Model instructions (grok-4.6)".into(), "generic".into())]
+        );
+        let only_model = o.sections("", "grok-4.6");
+        assert_eq!(only_model.len(), 1);
+        assert!(o.sections("xai", "missing").is_empty());
+        assert!(o.sections("", "").is_empty());
+        assert!(SystemPromptOverlays::default().is_empty());
     }
 }
 

--- a/crates/sdk/src/client.rs
+++ b/crates/sdk/src/client.rs
@@ -106,10 +106,14 @@ impl WhyCodesClient {
     /// The child inherits this process's environment (API keys, `HOME`), so
     /// it spends the same provider quota as the user. `close` / drop kills it.
     pub async fn launch(opts: LaunchOptions) -> Result<Self, SdkError> {
-        let prepared = prepare_launch(&opts)?;
-        if let Some(err) = missing_spawned_binary(&prepared.binary) {
+        // Classify a missing binary before create_temp_home. A sibling test
+        // that injects tempdir failure must not turn ServeNotFound into
+        // StartupFailed, and a dead path should not allocate WHYCODES_HOME.
+        let binary = resolve_binary(opts.binary.as_deref())?;
+        if let Some(err) = missing_spawned_binary(&binary) {
             return Err(err);
         }
+        let prepared = prepare_launch(&opts)?;
         let mut cmd = launch_command(&prepared, &opts);
         let child = cmd.spawn().map_err(|e| {
             SdkError::with_source(
@@ -843,9 +847,35 @@ fn poll_child_exit(child: Option<&mut Child>) -> Option<String> {
     }
 }
 
+#[cfg(test)]
+thread_local! {
+    static TEST_TEMPDIR_FAIL: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Process-wide `WHYCODES_TEST_TEMPDIR_FAIL` leaked into parallel `launch`
+/// tests (ServeNotFound became StartupFailed). Thread-local stays on the
+/// current-thread tokio test runtime.
+#[cfg(test)]
+pub(crate) struct TestTempdirFailGuard;
+
+#[cfg(test)]
+impl TestTempdirFailGuard {
+    pub(crate) fn arm() -> Self {
+        TEST_TEMPDIR_FAIL.with(|c| c.set(true));
+        Self
+    }
+}
+
+#[cfg(test)]
+impl Drop for TestTempdirFailGuard {
+    fn drop(&mut self) {
+        TEST_TEMPDIR_FAIL.with(|c| c.set(false));
+    }
+}
+
 fn create_temp_home() -> std::io::Result<tempfile::TempDir> {
     #[cfg(test)]
-    if std::env::var_os("WHYCODES_TEST_TEMPDIR_FAIL").is_some() {
+    if TEST_TEMPDIR_FAIL.with(std::cell::Cell::get) {
         return Err(std::io::Error::other("injected tempdir failure"));
     }
     tempfile::tempdir()

--- a/crates/sdk/src/client_tests.rs
+++ b/crates/sdk/src/client_tests.rs
@@ -540,16 +540,32 @@ async fn launch_missing_binary_is_serve_not_found() {
         Ok(_) => panic!("expected ServeNotFound"),
     };
     assert_eq!(err.code, ErrorCode::ServeNotFound);
+
+    // Armed tempdir-fail must not steal ServeNotFound (CI flake on Linux).
+    let _fail = super::TestTempdirFailGuard::arm();
+    let err = match WhyCodesClient::launch(LaunchOptions {
+        binary: Some(PathBuf::from("/no/such/whycodes-binary")),
+        inherit_logins: false,
+        startup_timeout: Duration::from_millis(200),
+        ..Default::default()
+    })
+    .await
+    {
+        Err(e) => e,
+        Ok(_) => panic!("expected ServeNotFound"),
+    };
+    assert_eq!(err.code, ErrorCode::ServeNotFound);
 }
 
 #[tokio::test]
 async fn launch_temp_home_create_failure_is_startup_failed() {
     let dir = tempfile::tempdir().unwrap();
-    let blocker = dir.path().join("not-a-dir");
-    std::fs::write(&blocker, b"x").unwrap();
+    let dummy = dir.path().join("unused");
+    std::fs::write(&dummy, b"").unwrap();
+    let _fail = super::TestTempdirFailGuard::arm();
     let err = match WhyCodesClient::launch(LaunchOptions {
         working_dir: dir.path().to_path_buf(),
-        binary: Some(dir.path().join("unused")),
+        binary: Some(dummy),
         inherit_logins: false,
         home: None,
         startup_timeout: Duration::from_millis(200),
@@ -558,15 +574,9 @@ async fn launch_temp_home_create_failure_is_startup_failed() {
     .await
     {
         Err(e) => e,
-        Ok(_) => panic!("expected StartupFailed or ServeNotFound"),
+        Ok(_) => panic!("expected StartupFailed"),
     };
-    assert!(
-        matches!(
-            err.code,
-            ErrorCode::StartupFailed | ErrorCode::ServeNotFound
-        ),
-        "{err:?}"
-    );
+    assert_eq!(err.code, ErrorCode::StartupFailed, "{err:?}");
 }
 
 #[tokio::test]
@@ -574,9 +584,12 @@ async fn launch_home_create_failure_is_startup_failed() {
     let dir = tempfile::tempdir().unwrap();
     let file = dir.path().join("not-a-dir");
     std::fs::write(&file, b"x").unwrap();
+    // Present so launch does not classify a missing binary first.
+    let dummy = dir.path().join("unused");
+    std::fs::write(&dummy, b"").unwrap();
     let err = match WhyCodesClient::launch(LaunchOptions {
         working_dir: dir.path().to_path_buf(),
-        binary: Some(dir.path().join("unused")),
+        binary: Some(dummy),
         inherit_logins: true,
         home: Some(file.join("nested")),
         startup_timeout: Duration::from_millis(200),
@@ -594,15 +607,12 @@ async fn launch_home_create_failure_is_startup_failed() {
 #[tokio::test]
 async fn launch_injected_tempdir_failure_is_startup_failed() {
     let dir = tempfile::tempdir().unwrap();
-    let prev = {
-        let _lock = env_lock();
-        let prev = std::env::var_os("WHYCODES_TEST_TEMPDIR_FAIL");
-        unsafe { std::env::set_var("WHYCODES_TEST_TEMPDIR_FAIL", "1") };
-        prev
-    };
+    let dummy = dir.path().join("unused");
+    std::fs::write(&dummy, b"").unwrap();
+    let _fail = super::TestTempdirFailGuard::arm();
     let err = match WhyCodesClient::launch(LaunchOptions {
         working_dir: dir.path().to_path_buf(),
-        binary: Some(dir.path().join("unused")),
+        binary: Some(dummy),
         inherit_logins: false,
         home: None,
         startup_timeout: Duration::from_millis(200),
@@ -613,13 +623,6 @@ async fn launch_injected_tempdir_failure_is_startup_failed() {
         Err(e) => e,
         Ok(_) => panic!("expected injected tempdir failure"),
     };
-    {
-        let _lock = env_lock();
-        match prev {
-            Some(v) => unsafe { std::env::set_var("WHYCODES_TEST_TEMPDIR_FAIL", v) },
-            None => unsafe { std::env::remove_var("WHYCODES_TEST_TEMPDIR_FAIL") },
-        }
-    }
     assert_eq!(err.code, ErrorCode::StartupFailed);
     assert!(err.message.contains("temp WHYCODES_HOME"), "{err:?}");
 }

--- a/crates/server/src/routes.rs
+++ b/crates/server/src/routes.rs
@@ -86,11 +86,13 @@ fn find_share_file_in(dirs: &[PathBuf], id: &str, ext: &str) -> Option<PathBuf> 
     None
 }
 
-pub(crate) fn system_prompt_for(agent: &Agent, project: &std::path::Path) -> String {
-    Agent::with_agents_md(
-        &Agent::with_runtime_context(&agent.system_prompt()),
-        project,
-    )
+pub(crate) fn system_prompt_for(
+    agent: &Agent,
+    project: &std::path::Path,
+    provider: &str,
+    model: &str,
+) -> String {
+    Agent::with_agents_md(&agent.system_prompt_for_route(provider, model), project)
 }
 
 /// Env → config api_key → OAuth store (mirrors CLI `get_api_key`).
@@ -122,7 +124,7 @@ pub(crate) async fn resolve_api_key(
     None
 }
 
-pub(crate) fn default_provider_model(config: &whycodes_config::Config) -> (String, String) {
+pub fn default_provider_model(config: &whycodes_config::Config) -> (String, String) {
     if let Some(dm) = &config.default_model {
         return (dm.provider_id.clone(), dm.model_id.clone());
     }
@@ -275,7 +277,8 @@ pub async fn create_session(
         .project
         .map(PathBuf::from)
         .unwrap_or_else(|| state.project_dir.clone());
-    let prompt = system_prompt_for(&state.agent, &project);
+    let (provider, model) = default_provider_model(&state.config);
+    let prompt = system_prompt_for(&state.agent, &project, &provider, &model);
     let session = Session::new(project, prompt);
     let id = session.id.clone();
     let title = session.title.clone();

--- a/crates/server/src/routes_tests.rs
+++ b/crates/server/src/routes_tests.rs
@@ -407,7 +407,7 @@ async fn load_or_get_session_returns_none_when_db_unavailable() {
 #[test]
 fn system_prompt_includes_runtime_context() {
     let state = crate::http_tests::test_state();
-    let prompt = system_prompt_for(&state.agent, &state.project_dir);
+    let prompt = system_prompt_for(&state.agent, &state.project_dir, "xai", "grok-4.6");
     assert!(prompt.contains("Today's date:"), "{prompt}");
 }
 

--- a/crates/server/src/v1.rs
+++ b/crates/server/src/v1.rs
@@ -101,7 +101,8 @@ pub async fn create_session(
         .project
         .map(PathBuf::from)
         .unwrap_or_else(|| state.project_dir.clone());
-    let prompt = system_prompt_for(&state.agent, &project);
+    let (provider, model) = default_provider_model(&state.config);
+    let prompt = system_prompt_for(&state.agent, &project, &provider, &model);
     let session = whycodes_session::session::Session::new(project, prompt);
     let persist = req.persist.unwrap_or(true);
     if persist {
@@ -372,11 +373,21 @@ pub async fn set_model(
     Path(id): Path<String>,
     Json(req): Json<SetModelRequest>,
 ) -> Result<StatusCode, StatusCode> {
-    load_or_get_session(&state, &id)
+    let handle = load_or_get_session(&state, &id)
         .await
         .ok_or(StatusCode::NOT_FOUND)?;
     if req.provider.trim().is_empty() || req.model.trim().is_empty() {
         return Err(StatusCode::BAD_REQUEST);
+    }
+    {
+        let mut session = handle.lock().await;
+        let prompt = system_prompt_for(
+            &state.agent,
+            &session.project_path,
+            &req.provider,
+            &req.model,
+        );
+        session.set_system_prompt(&prompt);
     }
     if let Ok(mut map) = state.session_route.lock() {
         map.insert(id, (req.provider, req.model));

--- a/crates/tools/src/git/commit_tests.rs
+++ b/crates/tools/src/git/commit_tests.rs
@@ -77,16 +77,17 @@ fn commit_module_loads() {
 }
 
 fn fail_status() -> std::process::ExitStatus {
+    // Do not spawn `false`/`cmd`: sibling tests empty PATH under ENV_LOCK
+    // (commit_fails_when_git_missing_from_path) and this helper is not locked.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(1 << 8)
+    }
     #[cfg(windows)]
     {
-        Command::new("cmd")
-            .args(["/C", "exit", "1"])
-            .status()
-            .unwrap()
-    }
-    #[cfg(not(windows))]
-    {
-        Command::new("false").status().unwrap()
+        use std::os::windows::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(1)
     }
 }
 

--- a/crates/tools/src/web/browser_tests.rs
+++ b/crates/tools/src/web/browser_tests.rs
@@ -451,30 +451,28 @@ fn find_browser_and_http_get_without_slash() {
 }
 
 fn fail_cmd_status() -> std::process::ExitStatus {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(1 << 8)
+    }
     #[cfg(windows)]
     {
-        Command::new("cmd")
-            .args(["/C", "exit", "1"])
-            .status()
-            .unwrap()
-    }
-    #[cfg(not(windows))]
-    {
-        Command::new("false").status().unwrap()
+        use std::os::windows::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(1)
     }
 }
 
 fn ok_cmd_status() -> std::process::ExitStatus {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(0)
+    }
     #[cfg(windows)]
     {
-        Command::new("cmd")
-            .args(["/C", "exit", "0"])
-            .status()
-            .unwrap()
-    }
-    #[cfg(not(windows))]
-    {
-        Command::new("true").status().unwrap()
+        use std::os::windows::process::ExitStatusExt;
+        std::process::ExitStatus::from_raw(0)
     }
 }
 

--- a/crates/tui/src/run/mod.rs
+++ b/crates/tui/src/run/mod.rs
@@ -593,14 +593,9 @@ async fn prepare_tui_runtime(opts: &TuiRunOptions, app: &mut TuiApp) -> TuiRunti
         .cloned()
         .unwrap_or_else(|| default_agent_info(&opts.agent_name));
 
-    let base = agent_info
-        .system_prompt
-        .clone()
-        .unwrap_or_else(|| Agent::system_prompt_for(&opts.agent_name));
     // Deferred: AGENTS.md + memory + plugins each touch disk/SQLite. Home has
     // no fenced code and needs no tool plugins, so the first frame uses a
     // minimal prompt; the full prompt is hydrated after paint.
-    let system_prompt = Agent::with_runtime_context(&base);
 
     let (perm_prompter, perm_rx) = ChannelPermissionPrompter::new();
     let perm_prompter =
@@ -629,8 +624,10 @@ async fn prepare_tui_runtime(opts: &TuiRunOptions, app: &mut TuiApp) -> TuiRunti
             Arc::clone(&perm_prompter) as Arc<dyn whycodes_agent::PermissionPrompter>
         )
         .with_question_prompter(Arc::clone(&question_prompter) as Arc<dyn QuestionPrompter>);
+    agent.set_route(&opts.provider, &opts.model);
     agent.set_approval_mode(app.approval_mode);
     inject_test_llm(&mut agent, &opts.provider);
+    let system_prompt = agent.system_prompt();
 
     let mut session = Session::new(opts.project_dir.clone(), system_prompt.clone());
     app.session_title = session.title.clone();
@@ -1704,6 +1701,7 @@ pub async fn run(opts: TuiRunOptions) -> anyhow::Result<TuiExit> {
             while let Ok(ev) = auth_rx.try_recv() {
                 apply_auth_flow_event(
                     &mut app,
+                    &mut rt,
                     ev,
                     &mut provider,
                     &mut model,
@@ -2339,6 +2337,8 @@ async fn apply_idle_loop_key(
                 project_dir,
                 file_index,
                 session_claims.clone(),
+                provider,
+                model,
             )
             .await;
             adopt_fresh_runtime(app, rt, runtimes, mru, fresh);
@@ -2771,24 +2771,18 @@ fn rebuild_agent_after_force_stop(
                 temperature: None,
                 top_p: None,
             });
-    let base = info
-        .system_prompt
-        .clone()
-        .unwrap_or_else(|| Agent::system_prompt_for(&info.name));
-    let prompt = with_project_memory(
-        &Agent::with_agents_md(&base, project_dir),
-        project_dir,
-        config,
-        None,
-    );
     let bg = agent.background_registry().clone();
     let claims = agent.session_claims();
+    let (route_provider, route_model) = agent.route();
+    let route_provider = route_provider.to_string();
+    let route_model = route_model.to_string();
     let mut next = Agent::new(info)
         .with_config(config)
         .with_background_registry(bg)
         .with_file_index(file_index.clone())
         .with_permission_prompter(perm_prompter as Arc<dyn whycodes_agent::PermissionPrompter>)
         .with_question_prompter(question_prompter as Arc<dyn QuestionPrompter>);
+    next.set_route(&route_provider, &route_model);
     if let Some(c) = claims {
         next = next.with_session_claims(c);
     }
@@ -2796,6 +2790,15 @@ fn rebuild_agent_after_force_stop(
     agent.wire_event_sink(event_tx);
     // Keep existing system prompt on session if any; else set rebuilt one.
     if session.system_prompt.is_empty() {
+        let prompt = with_project_memory(
+            &Agent::with_agents_md(
+                &agent.system_prompt_for_route(&route_provider, &route_model),
+                project_dir,
+            ),
+            project_dir,
+            config,
+            None,
+        );
         session.set_system_prompt(&prompt);
     }
 }
@@ -2833,12 +2836,15 @@ fn format_turn_done_status(
 /// Build a fresh runtime for a new empty session (Ctrl+N). Owns its
 /// prompter pair and channels; the agent shares no state with any other
 /// runtime except the process-wide background registry pattern.
+#[allow(clippy::too_many_arguments)]
 async fn spawn_new_session_runtime(
     agent_name: &str,
     config: &Config,
     project_dir: &std::path::Path,
     file_index: &Arc<whycodes_index::WorkspaceIndex>,
     session_claims: whycodes_core::FileClaimRegistry,
+    provider: &str,
+    model: &str,
 ) -> SessionRuntime {
     let agent_info =
         config
@@ -2859,17 +2865,6 @@ async fn spawn_new_session_runtime(
                 temperature: None,
                 top_p: None,
             });
-    let base = agent_info
-        .system_prompt
-        .clone()
-        .unwrap_or_else(|| Agent::system_prompt_for(agent_name));
-    let system_prompt = with_project_memory(
-        &Agent::with_agents_md(&base, project_dir),
-        project_dir,
-        config,
-        None,
-    );
-
     let (perm_prompter, perm_rx) = ChannelPermissionPrompter::new();
     let perm_prompter =
         perm_prompter.with_notify(whycodes_agent::notify::handle_from_config(&config.notify));
@@ -2894,8 +2889,15 @@ async fn spawn_new_session_runtime(
             Arc::clone(&perm_prompter) as Arc<dyn whycodes_agent::PermissionPrompter>
         )
         .with_question_prompter(Arc::clone(&question_prompter) as Arc<dyn QuestionPrompter>);
+    agent.set_route(provider, model);
     agent.set_approval_mode(config.general.approval_mode.unwrap_or_default());
     agent = agent.with_mcp(config).await;
+    let system_prompt = with_project_memory(
+        &Agent::with_agents_md(&agent.system_prompt_for_route(provider, model), project_dir),
+        project_dir,
+        config,
+        None,
+    );
 
     let session = Session::new(project_dir.to_path_buf(), system_prompt);
     let history = SessionHistory::new();
@@ -3527,8 +3529,9 @@ fn resume_or_switch_session(
             let n = loaded.messages.len();
             rt.history = SessionHistory::new();
             rt.session = loaded;
+            let (p, m) = rt.agent.route();
             rt.session.system_prompt = with_project_memory(
-                &Agent::with_agents_md(&rt.agent.system_prompt(), project_dir),
+                &Agent::with_agents_md(&rt.agent.system_prompt_for_route(p, m), project_dir),
                 project_dir,
                 config,
                 None,
@@ -3659,6 +3662,8 @@ async fn apply_pending_picker_choices(
 ) {
     if let Some((p, m)) = app.pending_model.take() {
         apply_model_choice(app, provider, model, api_key, p, m, config);
+        rt.agent.set_route(provider, model);
+        refresh_session_memory(&mut rt.session, &rt.agent, &app.project_dir, config, None);
         fill_oauth_credential(api_key, provider).await;
         defer_or_spawn_catalog(
             rt.agent_busy,
@@ -3744,6 +3749,7 @@ fn apply_catalog_window(
 
 async fn apply_auth_flow_event(
     app: &mut TuiApp,
+    rt: &mut SessionRuntime,
     ev: AuthFlowEvent,
     provider: &mut String,
     model: &mut String,
@@ -3774,6 +3780,14 @@ async fn apply_auth_flow_event(
                         .find(|name| !name.is_empty())
                         .unwrap_or_else(|| model.clone());
                     apply_model_choice(app, provider, model, api_key, p.clone(), m, config);
+                    rt.agent.set_route(provider, model);
+                    refresh_session_memory(
+                        &mut rt.session,
+                        &rt.agent,
+                        &app.project_dir,
+                        config,
+                        None,
+                    );
                 }
                 if let Ok(dir) = Config::data_dir()
                     && let Some(tok) = whycodes_auth::providers::access_token(&p, &dir).await
@@ -5004,7 +5018,7 @@ async fn hydrate_after_first_frame(
     rt.agent.set_file_index(real.clone());
     *file_index = real;
     rt.agent.hydrate_plugins(Some(project_dir));
-    hydrate_full_system_prompt(rt, project_dir, config);
+    hydrate_full_system_prompt(rt, project_dir, config, provider, model);
     hydrate_session_picker(app);
     hydrate_deferred_api_key(api_key, provider, model, config, app);
     rt.agent.load_mcp(config).await;
@@ -5041,9 +5055,16 @@ fn hydrate_full_system_prompt(
     rt: &mut SessionRuntime,
     project_dir: &std::path::Path,
     config: &Config,
+    provider: &str,
+    model: &str,
 ) {
-    let base = rt.agent.system_prompt();
-    let with_agents = whycodes_agent::agent::Agent::with_agents_md(&base, project_dir);
+    rt.agent
+        .set_system_prompt_overlays(config.system_prompt_overlays.clone());
+    rt.agent.set_route(provider, model);
+    let with_agents = whycodes_agent::agent::Agent::with_agents_md(
+        &rt.agent.system_prompt_for_route(provider, model),
+        project_dir,
+    );
     let full = with_project_memory(&with_agents, project_dir, config, None);
     rt.session.set_system_prompt(&full);
 }
@@ -5149,16 +5170,9 @@ async fn switch_to_agent(
     };
     app.toasts.push(crate::toast::ToastKind::Info, toast);
     if let Some(info) = config.get_agent(name).cloned() {
-        let base = info
-            .system_prompt
-            .clone()
-            .unwrap_or_else(|| Agent::system_prompt_for(name));
-        let prompt = with_project_memory(
-            &Agent::with_agents_md(&base, project_dir),
-            project_dir,
-            config,
-            None,
-        );
+        let (route_provider, route_model) = agent.route();
+        let route_provider = route_provider.to_string();
+        let route_model = route_model.to_string();
         let bg = agent.background_registry().clone();
         let claims = agent.session_claims();
         let mut next = Agent::new(info)
@@ -5168,11 +5182,21 @@ async fn switch_to_agent(
                 Arc::clone(&perm_prompter) as Arc<dyn whycodes_agent::PermissionPrompter>
             )
             .with_question_prompter(Arc::clone(&question_prompter) as Arc<dyn QuestionPrompter>);
+        next.set_route(&route_provider, &route_model);
         if let Some(c) = claims {
             next = next.with_session_claims(c);
         }
         *agent = next;
         agent.wire_event_sink(event_tx.clone());
+        let prompt = with_project_memory(
+            &Agent::with_agents_md(
+                &agent.system_prompt_for_route(&route_provider, &route_model),
+                project_dir,
+            ),
+            project_dir,
+            config,
+            None,
+        );
         session.set_system_prompt(&prompt);
     }
 }

--- a/crates/tui/src/run/persist.rs
+++ b/crates/tui/src/run/persist.rs
@@ -259,7 +259,8 @@ pub(super) fn refresh_session_memory(
     config: &Config,
     query: Option<&str>,
 ) {
-    let base = Agent::with_agents_md(&agent.system_prompt(), project_dir);
+    let (provider, model) = agent.route();
+    let base = Agent::with_agents_md(&agent.system_prompt_for_route(provider, model), project_dir);
     session.set_system_prompt(&with_project_memory(&base, project_dir, config, query));
 }
 

--- a/crates/tui/src/run/slash.rs
+++ b/crates/tui/src/run/slash.rs
@@ -163,7 +163,10 @@ pub(super) async fn handle_slash(text: &str, ctx: &mut SlashContext<'_>) {
             *ctx.session = Session::new(
                 ctx.project_dir.to_path_buf(),
                 with_project_memory(
-                    &Agent::with_agents_md(&ctx.agent.system_prompt(), ctx.project_dir),
+                    &Agent::with_agents_md(
+                        &ctx.agent.system_prompt_for_route(ctx.provider, ctx.model),
+                        ctx.project_dir,
+                    ),
                     ctx.project_dir,
                     ctx.config,
                     None,
@@ -434,20 +437,21 @@ pub(super) async fn handle_slash(text: &str, ctx: &mut SlashContext<'_>) {
             if rest.is_empty() {
                 crate::input::open_agent_dialog(ctx.app);
             } else if let Some(info) = ctx.config.get_agent(rest).cloned() {
-                let base = info
-                    .system_prompt
-                    .clone()
-                    .unwrap_or_else(|| Agent::system_prompt_for(rest));
-                let prompt = with_project_memory(
-                    &Agent::with_agents_md(&base, ctx.project_dir),
-                    ctx.project_dir,
-                    ctx.config,
-                    None,
-                );
-                *ctx.agent = bind_agent_prompters(
+                let mut next = bind_agent_prompters(
                     Agent::new(info).with_config(ctx.config),
                     &ctx.perm_prompter,
                     &ctx.question_prompter,
+                );
+                next.set_route(ctx.provider, ctx.model);
+                *ctx.agent = next;
+                let prompt = with_project_memory(
+                    &Agent::with_agents_md(
+                        &ctx.agent.system_prompt_for_route(ctx.provider, ctx.model),
+                        ctx.project_dir,
+                    ),
+                    ctx.project_dir,
+                    ctx.config,
+                    None,
                 );
                 ctx.session.set_system_prompt(&prompt);
                 if let Some(idx) = ctx.app.primary_agents.iter().position(|n| n == rest) {
@@ -504,11 +508,15 @@ pub(super) async fn handle_slash(text: &str, ctx: &mut SlashContext<'_>) {
                     m.to_string(),
                     ctx.config,
                 );
+                ctx.agent.set_route(ctx.provider, ctx.model);
+                refresh_session_memory(ctx.session, ctx.agent, ctx.project_dir, ctx.config, None);
                 fill_oauth_credential(ctx.api_key, ctx.provider).await;
                 ctx.app.pending_catalog_refresh = true;
             } else {
                 *ctx.model = rest.to_string();
                 ctx.app.model_name = rest.to_string();
+                ctx.agent.set_route(ctx.provider, ctx.model);
+                refresh_session_memory(ctx.session, ctx.agent, ctx.project_dir, ctx.config, None);
                 refresh_context_window(ctx.app, ctx.config, ctx.provider, rest);
                 ctx.app.status_message = format!(
                     "Model → {}  ·  window {}",

--- a/crates/tui/src/run/tests.rs
+++ b/crates/tui/src/run/tests.rs
@@ -3079,6 +3079,8 @@ async fn spawn_runtime_and_drain_outcomes() {
         dir.path(),
         &idx,
         whycodes_core::FileClaimRegistry::new(),
+        "xai",
+        "grok-4.6",
     )
     .await;
     assert_eq!(rt.agent.info.name, "no-such-agent");
@@ -4200,8 +4202,10 @@ async fn apply_auth_flow_note_code_and_results() {
     let mut provider = "anthropic".to_string();
     let mut model = "claude-sonnet-5".to_string();
     let config = Config::default();
+    let mut rt = test_runtime();
     apply_auth_flow_event(
         &mut app,
+        &mut rt,
         AuthFlowEvent::Note("Visit https://x\nthen paste".into()),
         &mut provider,
         &mut model,
@@ -4214,6 +4218,7 @@ async fn apply_auth_flow_note_code_and_results() {
     let (tx, _rx) = tokio::sync::oneshot::channel();
     apply_auth_flow_event(
         &mut app,
+        &mut rt,
         AuthFlowEvent::NeedCode(tx),
         &mut provider,
         &mut model,
@@ -4226,6 +4231,7 @@ async fn apply_auth_flow_note_code_and_results() {
 
     apply_auth_flow_event(
         &mut app,
+        &mut rt,
         AuthFlowEvent::Done {
             provider: "anthropic".into(),
             result: Err("nope".into()),
@@ -4240,6 +4246,7 @@ async fn apply_auth_flow_note_code_and_results() {
 
     apply_auth_flow_event(
         &mut app,
+        &mut rt,
         AuthFlowEvent::Done {
             provider: "openai".into(),
             result: Ok("ok".into()),
@@ -4263,6 +4270,7 @@ async fn apply_auth_flow_note_code_and_results() {
 
     apply_auth_flow_event(
         &mut app,
+        &mut rt,
         AuthFlowEvent::Done {
             provider: "openai".into(),
             result: Ok("already".into()),
@@ -4303,6 +4311,7 @@ async fn apply_auth_flow_note_code_and_results() {
     });
     apply_auth_flow_event(
         &mut app,
+        &mut rt,
         AuthFlowEvent::Done {
             provider: "tui-oauth-switch-demo".into(),
             result: Ok("ok".into()),
@@ -4318,6 +4327,7 @@ async fn apply_auth_flow_note_code_and_results() {
 
     apply_auth_flow_event(
         &mut app,
+        &mut rt,
         AuthFlowEvent::Done {
             provider: "tui-oauth-switch-demo".into(),
             result: Ok("ok".into()),

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -21,7 +21,7 @@ REPORT_JSON=/tmp/cov.json scripts/coverage.sh
 ```
 
 CI sets `COVERAGE_FEATURES=whycodes-storage/bundled` because the self-hosted
-runner has no `libsqlite3-dev`. Locally, omit it if system sqlite is
+runners have no `libsqlite3-dev`. Locally, omit it if system sqlite is
 installed (`pkg-config sqlite3`).
 
 - `--ignore-filename-regex '/usr/src/|/rustc-'` drops rustc sysroot files that

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -441,6 +441,16 @@ checkout so you do not have to migrate them: `CLAUDE.md`, `GEMINI.md`,
 is skipped. In a git repo, parent directories up to the repository root are
 included.
 
+Provider or model extras belong in markdown next to `config.toml` (or the
+project `.whycodes/` dir). Long prompts stay out of TOML:
+
+- `prompts/<provider>.md` — every model on that provider (`prompts/xai.md`)
+- `prompts/<provider>/<model>.md` — that provider+model (`prompts/xai/grok-4.6.md`)
+- `prompts/models/<model>.md` — that model id on any provider
+
+Project files overwrite the same key. Optional YAML frontmatter is stripped.
+Switching `/models` rebuilds the session system prompt.
+
 Skills are listed in the system prompt by **name and description only**. The
 body is loaded with `read skill://<name>` or `skill` (`action=load`). Project
 trees: `.skills/*.skill.md`, `.whycodes/skills/`, `.claude/skills/*/SKILL.md`.

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2320,3 +2320,19 @@ Interactive `run()` on **Linux, macOS, and Windows** now attaches and paints the
 Harness TTFF then dropped ratatui entirely: `write_splash_csi` is `SM?1049` + clear + one ASCII line. In-proc **0.1 ms**, spawn-to-exit **14.3 ms** (same band as `--version`). Do not put a `Terminal::new` / `QuantizingBackend` on that path.
 
 `--version` on Windows is `GetCommandLineW` + `WriteFile` of a `concat!` line — no clap, Tokio, `args_os`, or `println!`. Re-measure stayed **~14 ms**. Further cuts need a smaller PE / less CRT, not more Rust in `main`.
+
+## SDK launch: missing binary classified as StartupFailed under parallel tests
+
+**Date:** 2026-09-12 · **Area:** `crates/sdk/src/client.rs`
+
+**Symptom:** CI `Test (linux)` failed `client::tests::launch_missing_binary_is_serve_not_found`: `left: StartupFailed, right: ServeNotFound`. Isolated re-run is green. Coverage job still passed (it skips several launch tests).
+
+**JSONL / crash:** none.
+
+**Root cause:** `launch_injected_tempdir_failure_is_startup_failed` set process-wide `WHYCODES_TEST_TEMPDIR_FAIL` and dropped `env_lock` before the async `launch` body. A sibling `launch` then hit `create_temp_home` (isolation home) *before* the missing-binary check, so a dead path became `StartupFailed`.
+
+**Fix:** Classify `missing_spawned_binary` before `prepare_launch`. Inject the tempdir failure with a thread-local guard (`TestTempdirFailGuard`), not an env var. Home-create tests write a dummy file so the missing-binary path does not fire first.
+
+**Prevention:** Do not inject launch failures through process env while other `#[tokio::test]` launch tests run. Keep the missing-binary check ahead of temp-home allocation.
+
+Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs already have no edge between them; a single runner still serializes them. Extra self-hosted runners with separate `_work` dirs run them together.

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2336,3 +2336,17 @@ Harness TTFF then dropped ratatui entirely: `write_splash_csi` is `SM?1049` + cl
 **Prevention:** Do not inject launch failures through process env while other `#[tokio::test]` launch tests run. Keep the missing-binary check ahead of temp-home allocation.
 
 Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs already have no edge between them; a single runner still serializes them. Extra self-hosted runners with separate `_work` dirs run them together.
+
+## Coverage flake: `git::commit::tests::commit_module_loads` cannot spawn `false`
+
+**Date:** 2026-09-12 · **Area:** `crates/tools/src/git/commit_tests.rs`
+
+**Symptom:** Coverage (and any parallel `cargo test -p whycodes-tools`) panics `commit_module_loads` with `Os { kind: NotFound }` on `Command::new("false")`. Isolated re-run is green.
+
+**JSONL / crash:** none.
+
+**Root cause:** `commit_fails_when_git_missing_from_path` (and the other git `*_missing_from_path` tests) set process-wide `PATH=/nonexistent-whycodes-path` under `ENV_LOCK`. `fail_status()` did not take that lock and spawned `false` / `cmd /C exit 1` to build an `ExitStatus`.
+
+**Fix:** Build the failing `ExitStatus` with `ExitStatusExt::from_raw` (unix wait status `1 << 8`, Windows `1`). Same for the browser test helpers.
+
+**Prevention:** Helpers that only need a dummy `ExitStatus` must not spawn PATH binaries. Tests that mutate `PATH` already hold `ENV_LOCK`; unlocked tests must not depend on PATH.


### PR DESCRIPTION
Load optional provider/model extras from markdown so long system prompts stay out of TOML.

Layout (global next to config.toml, project .whycodes/prompts/ overwrites the same key):
- prompts/<provider>.md for every model on that provider
- prompts/<provider>/<model>.md for that provider+model
- prompts/models/<model>.md for that model id on any provider

Optional YAML frontmatter is stripped. Switching /models (and SDK POST /v1/sessions/:id/model) rebuilds the session system prompt.

Config loads overlays with command markdown; merge is project-wins. Agent appends provider then model extras after the role prompt, before AGENTS.md / runtime. CLI, TUI, serve, and subagents bind the active route so overlays apply.