### PR TITLE
feat(index): prune grep with in-memory content trigrams

### DIFF
--- a/crates/index/src/content.rs
+++ b/crates/index/src/content.rs
@@ -1,0 +1,305 @@
+//! In-memory content trigrams for grep candidate pruning.
+//!
+//! Overlapping 3-byte trigrams, the same filter Microsoft tgrep uses, but
+//! resident in the workspace index (no disk index, no TCP server). The grep
+//! tool still confirms with `grep-searcher`; this layer only drops files that
+//! cannot contain a required literal. Files not yet indexed are never dropped.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// Bytes of an overlapping trigram.
+pub const TRIGRAM_LEN: usize = 3;
+/// Files larger than this are skipped (grep also refuses to search them).
+pub const MAX_INDEX_BYTES: u64 = 1024 * 1024;
+/// NUL sniff window; matches the file-tools binary check.
+const BINARY_SNIFF: usize = 8192;
+
+/// Regex metacharacters that mean the pattern is not a single literal.
+const REGEX_META: &[char] = &[
+    '.', '^', '$', '*', '+', '?', '(', ')', '[', ']', '{', '}', '|',
+];
+
+/// Per-root overlay: relative path → unique sorted trigrams.
+#[derive(Debug, Default)]
+pub struct ContentIndex {
+    files: FxHashMap<Box<str>, Vec<u32>>,
+    skipped: FxHashSet<Box<str>>,
+    complete: bool,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum Load {
+    Bytes(Vec<u8>),
+    /// NUL / binary — grep will skip these too.
+    Binary,
+    /// Missing, symlink, directory, too large, or I/O error. Never prune.
+    Unknown,
+}
+
+impl ContentIndex {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&mut self) {
+        self.files.clear();
+        self.skipped.clear();
+        self.complete = false;
+    }
+
+    pub fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    pub fn mark_complete(&mut self) {
+        self.complete = true;
+    }
+
+    pub fn indexed_len(&self) -> usize {
+        self.files.len()
+    }
+
+    pub fn skipped_len(&self) -> usize {
+        self.skipped.len()
+    }
+
+    /// Re-read `rel` under `root` and replace its posting.
+    pub fn upsert(&mut self, root: &Path, rel: &str, size: u64) {
+        self.remove(rel);
+        match load_file(&root.join(rel), size) {
+            Load::Binary => {
+                self.skipped.insert(rel.into());
+            }
+            Load::Bytes(bytes) => {
+                self.files
+                    .insert(rel.into(), extract_indexed_trigrams(&bytes));
+            }
+            Load::Unknown => {}
+        }
+    }
+
+    pub fn remove(&mut self, rel: &str) {
+        self.files.remove(rel);
+        self.skipped.remove(rel);
+    }
+
+    /// Drop `rel` and every descendant (`rel/…`).
+    pub fn remove_tree(&mut self, rel: &str) {
+        self.remove(rel);
+        let prefix = tree_prefix(rel);
+        self.files.retain(|k, _| !k.starts_with(&prefix));
+        self.skipped.retain(|k| !k.starts_with(&prefix));
+    }
+
+    /// `true` when `rel` might contain every `required` trigram.
+    ///
+    /// Unknown paths (not yet filled, read error, symlink, too large) return
+    /// `true` so a partial overlay never hides a match. Binary paths return
+    /// `false` — the grep engine would skip them too.
+    pub fn may_match(&self, rel: &str, required: &[u32]) -> bool {
+        if required.is_empty() {
+            return true;
+        }
+        if self.skipped.contains(rel) {
+            return false;
+        }
+        match self.files.get(rel) {
+            None => true,
+            Some(tris) => contains_all(tris, required),
+        }
+    }
+}
+
+/// Pack three bytes into a `u32` key.
+pub fn pack_trigram(a: u8, b: u8, c: u8) -> u32 {
+    (u32::from(a) << 16) | (u32::from(b) << 8) | u32::from(c)
+}
+
+/// Unique sorted overlapping 3-byte trigrams. Empty when `bytes` is shorter
+/// than [`TRIGRAM_LEN`].
+pub fn extract_trigrams(bytes: &[u8]) -> Vec<u32> {
+    if bytes.len() < TRIGRAM_LEN {
+        return Vec::new();
+    }
+    let mut v: Vec<u32> = bytes
+        .windows(TRIGRAM_LEN)
+        .map(|w| pack_trigram(w[0], w[1], w[2]))
+        .collect();
+    v.sort_unstable();
+    v.dedup();
+    v
+}
+
+/// Required trigrams for a grep pattern, or `None` when the overlay must not
+/// prune (regex, too short, or Unicode case-fold).
+pub fn required_trigrams(pattern: &str, case_insensitive: bool) -> Option<Vec<u32>> {
+    if skip_unicode_casefold(pattern, case_insensitive) {
+        return None;
+    }
+    let literal = as_literal(pattern)?;
+    let bytes = if case_insensitive {
+        ascii_lower(literal.as_bytes())
+    } else {
+        literal.into_bytes()
+    };
+    if bytes.len() < TRIGRAM_LEN {
+        return None;
+    }
+    Some(extract_trigrams(&bytes))
+}
+
+/// Original-case trigrams plus ASCII-lowercased ones so a case-insensitive
+/// query can prune without hiding a case-sensitive match (false positives
+/// are confirmed by the grep engine; false negatives are not).
+fn extract_indexed_trigrams(bytes: &[u8]) -> Vec<u32> {
+    let mut v = extract_trigrams(bytes);
+    let lower = ascii_lower(bytes);
+    if lower.as_slice() != bytes {
+        v.extend(extract_trigrams(&lower));
+        v.sort_unstable();
+        v.dedup();
+    }
+    v
+}
+
+fn skip_unicode_casefold(pattern: &str, case_insensitive: bool) -> bool {
+    case_insensitive && pattern.bytes().any(|b| !b.is_ascii())
+}
+
+fn ascii_lower(bytes: &[u8]) -> Vec<u8> {
+    bytes.iter().map(|b| b.to_ascii_lowercase()).collect()
+}
+
+fn tree_prefix(rel: &str) -> String {
+    format!("{rel}/")
+}
+
+fn contains_all(hay: &[u32], needles: &[u32]) -> bool {
+    needles.iter().all(|n| hay.binary_search(n).is_ok())
+}
+
+/// Unescaped regex → `None`. Escaped metas become their literal character.
+fn as_literal(pattern: &str) -> Option<String> {
+    let mut out = String::with_capacity(pattern.len());
+    let mut chars = pattern.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            let n = chars.next()?;
+            if is_regex_meta(n) || n == '\\' {
+                out.push(n);
+            } else {
+                return None;
+            }
+        } else if is_regex_meta(c) {
+            return None;
+        } else {
+            out.push(c);
+        }
+    }
+    Some(out)
+}
+
+fn is_regex_meta(c: char) -> bool {
+    REGEX_META.contains(&c)
+}
+
+fn load_file(path: &Path, size_hint: u64) -> Load {
+    if size_hint > MAX_INDEX_BYTES {
+        return too_large();
+    }
+    classify_metadata(path)
+}
+
+fn classify_metadata(path: &Path) -> Load {
+    let Ok(md) = std::fs::symlink_metadata(path) else {
+        return missing_path();
+    };
+    if md.file_type().is_symlink() || md.is_dir() {
+        return skip_non_file();
+    }
+    if md.len() > MAX_INDEX_BYTES {
+        return too_large();
+    }
+    read_text_or_binary(path)
+}
+
+fn read_text_or_binary(path: &Path) -> Load {
+    let Ok(mut f) = File::open(path) else {
+        return open_failed();
+    };
+    let mut sniff = [0u8; BINARY_SNIFF];
+    classify_sniff(f.read(&mut sniff), &sniff, &mut f)
+}
+
+fn classify_sniff(result: std::io::Result<usize>, sniff: &[u8], f: &mut File) -> Load {
+    match result {
+        Ok(n) => {
+            let n = n.min(sniff.len());
+            if sniff[..n].contains(&0) {
+                return Load::Binary;
+            }
+            let mut buf = Vec::with_capacity(n);
+            buf.extend_from_slice(&sniff[..n]);
+            if n == BINARY_SNIFF {
+                append_rest(f, &mut buf)
+            } else {
+                Load::Bytes(buf)
+            }
+        }
+        Err(err) => {
+            tracing::debug!(error = %err, "content index sniff read failed");
+            read_failed()
+        }
+    }
+}
+
+fn append_rest(f: &mut File, buf: &mut Vec<u8>) -> Load {
+    let cap = MAX_INDEX_BYTES.saturating_sub(BINARY_SNIFF as u64);
+    let mut rest = Vec::new();
+    classify_append(f.take(cap).read_to_end(&mut rest), buf, rest)
+}
+
+fn classify_append(result: std::io::Result<usize>, buf: &mut Vec<u8>, rest: Vec<u8>) -> Load {
+    match result {
+        Ok(_) => {
+            buf.extend(rest);
+            Load::Bytes(std::mem::take(buf))
+        }
+        Err(err) => {
+            tracing::debug!(error = %err, "content index append read failed");
+            append_failed()
+        }
+    }
+}
+
+fn missing_path() -> Load {
+    Load::Unknown
+}
+
+fn skip_non_file() -> Load {
+    Load::Unknown
+}
+
+fn open_failed() -> Load {
+    Load::Unknown
+}
+
+fn read_failed() -> Load {
+    Load::Unknown
+}
+
+fn append_failed() -> Load {
+    Load::Unknown
+}
+
+fn too_large() -> Load {
+    Load::Unknown
+}
+
+#[cfg(test)]
+#[path = "content_tests.rs"]
+mod tests;

--- a/crates/index/src/content_tests.rs
+++ b/crates/index/src/content_tests.rs
@@ -1,0 +1,237 @@
+use super::*;
+use std::fs;
+use std::io::Write;
+
+fn tmp() -> tempfile::TempDir {
+    tempfile::TempDir::new().unwrap()
+}
+
+#[test]
+fn pack_and_extract_unique_sorted() {
+    assert_eq!(pack_trigram(b'a', b'b', b'c'), 0x00_61_62_63);
+    assert!(extract_trigrams(b"ab").is_empty());
+    assert_eq!(
+        extract_trigrams(b"abc"),
+        vec![pack_trigram(b'a', b'b', b'c')]
+    );
+    let tris = extract_trigrams(b"aaaa");
+    assert_eq!(tris, vec![pack_trigram(b'a', b'a', b'a')]);
+    let mixed = extract_indexed_trigrams(b"Abc");
+    assert!(mixed.contains(&pack_trigram(b'A', b'b', b'c')));
+    assert!(mixed.contains(&pack_trigram(b'a', b'b', b'c')));
+    assert_eq!(extract_indexed_trigrams(b"abc"), extract_trigrams(b"abc"));
+}
+
+#[test]
+fn required_trigrams_literal_and_escape() {
+    let t = required_trigrams("fn main", false).unwrap();
+    assert!(t.contains(&pack_trigram(b'f', b'n', b' ')));
+    assert!(required_trigrams("ab", false).is_none());
+    assert!(required_trigrams("a.b", false).is_none());
+    assert!(required_trigrams("a*", false).is_none());
+    let escaped = required_trigrams(r"a\.b", false).unwrap();
+    assert_eq!(escaped, extract_trigrams(b"a.b"));
+    assert!(required_trigrams(r"\d+", false).is_none());
+    assert!(required_trigrams(r"\x", false).is_none());
+    assert!(required_trigrams(r"trailing\", false).is_none());
+    let slash = required_trigrams(r"a\\b", false).unwrap();
+    assert_eq!(slash, extract_trigrams(br"a\b"));
+}
+
+#[test]
+fn required_trigrams_case_fold() {
+    let a = required_trigrams("Hello", true).unwrap();
+    let b = required_trigrams("hello", false).unwrap();
+    assert_eq!(a, b);
+    let cs = required_trigrams("Hello", false).unwrap();
+    assert_ne!(cs, b);
+    assert!(required_trigrams("İstanbul", true).is_none());
+    assert!(required_trigrams("İstanbul", false).is_some());
+}
+
+#[test]
+fn as_literal_rejects_each_meta() {
+    for c in REGEX_META {
+        assert!(as_literal(&format!("a{c}b")).is_none(), "{c}");
+    }
+    assert_eq!(as_literal("plain").as_deref(), Some("plain"));
+    assert_eq!(as_literal(r"\.\*\+").as_deref(), Some(".*+"));
+}
+
+#[test]
+fn content_index_upsert_match_and_skip() {
+    let dir = tmp();
+    let root = dir.path();
+    fs::write(root.join("hit.rs"), "fn unique_needle() {}\n").unwrap();
+    fs::write(root.join("miss.rs"), "fn other() {}\n").unwrap();
+    fs::write(root.join("bin.dat"), b"abc\0def").unwrap();
+    fs::write(root.join("tiny.rs"), "ab").unwrap();
+    fs::create_dir_all(root.join("src")).unwrap();
+
+    let mut idx = ContentIndex::new();
+    assert!(!idx.is_complete());
+    idx.upsert(root, "hit.rs", 0);
+    idx.upsert(root, "miss.rs", 0);
+    idx.upsert(root, "bin.dat", 0);
+    idx.upsert(root, "tiny.rs", 0);
+    idx.upsert(root, "src", 0);
+    idx.upsert(root, "gone.rs", 0);
+    idx.mark_complete();
+    assert!(idx.is_complete());
+    assert_eq!(idx.indexed_len(), 3);
+    assert_eq!(idx.skipped_len(), 1);
+
+    let req = required_trigrams("unique_needle", false).unwrap();
+    assert!(idx.may_match("hit.rs", &req));
+    assert!(!idx.may_match("miss.rs", &req));
+    assert!(!idx.may_match("bin.dat", &req));
+    assert!(idx.may_match("gone.rs", &req));
+    assert!(!idx.may_match("tiny.rs", &req));
+    assert!(idx.may_match("hit.rs", &[]));
+
+    idx.remove("hit.rs");
+    assert!(idx.may_match("hit.rs", &req));
+
+    fs::write(root.join("Case.rs"), "HelloWorld\n").unwrap();
+    idx.upsert(root, "Case.rs", 0);
+    let mixed = required_trigrams("HelloWorld", false).unwrap();
+    assert!(idx.may_match("Case.rs", &mixed));
+    let lower_req = required_trigrams("helloworld", true).unwrap();
+    assert!(idx.may_match("Case.rs", &lower_req));
+    let all_caps = required_trigrams("HELLOWORLD", false).unwrap();
+    assert!(!idx.may_match("Case.rs", &all_caps));
+
+    idx.clear();
+    assert!(!idx.is_complete());
+    assert_eq!(idx.indexed_len(), 0);
+}
+
+#[test]
+fn content_index_size_hint_and_remove_tree() {
+    let dir = tmp();
+    let root = dir.path();
+    fs::create_dir_all(root.join("src/nested")).unwrap();
+    fs::write(root.join("src/a.rs"), "fn alpha() {}\n").unwrap();
+    fs::write(root.join("src/nested/b.rs"), "fn beta() {}\n").unwrap();
+    fs::write(root.join("keep.rs"), "fn keep() {}\n").unwrap();
+
+    let mut idx = ContentIndex::new();
+    idx.upsert(root, "src/a.rs", 0);
+    idx.upsert(root, "src/nested/b.rs", 0);
+    idx.upsert(root, "keep.rs", 0);
+    idx.upsert(root, "huge.rs", MAX_INDEX_BYTES + 1);
+    assert_eq!(idx.skipped_len(), 0);
+    let huge_req = required_trigrams("alpha", false).unwrap();
+    assert!(idx.may_match("huge.rs", &huge_req));
+
+    let req = required_trigrams("alpha", false).unwrap();
+    assert!(idx.may_match("src/a.rs", &req));
+    idx.remove_tree("src");
+    assert!(idx.may_match("src/a.rs", &req));
+    assert!(idx.may_match("src/nested/b.rs", &req));
+    let keep = required_trigrams("keep", false).unwrap();
+    assert!(idx.may_match("keep.rs", &keep));
+}
+
+#[test]
+fn classify_metadata_skips_dir_and_missing() {
+    let dir = tmp();
+    assert_eq!(classify_metadata(dir.path()), Load::Unknown);
+    assert_eq!(
+        classify_metadata(&dir.path().join("nope.rs")),
+        Load::Unknown
+    );
+    let p = dir.path().join("ok.rs");
+    fs::write(&p, "hello world").unwrap();
+    match classify_metadata(&p) {
+        Load::Bytes(b) => assert_eq!(b, b"hello world"),
+        other => panic!("{other:?}"),
+    }
+    let big = dir.path().join("big.rs");
+    fs::write(&big, "x").unwrap();
+    let f = fs::OpenOptions::new().write(true).open(&big).unwrap();
+    f.set_len(MAX_INDEX_BYTES + 1).unwrap();
+    drop(f);
+    assert_eq!(classify_metadata(&big), Load::Unknown);
+}
+
+#[test]
+fn load_file_and_read_helpers() {
+    let dir = tmp();
+    let p = dir.path().join("a.rs");
+    fs::write(&p, "abc").unwrap();
+    match load_file(&p, 3) {
+        Load::Bytes(b) => assert_eq!(b, b"abc"),
+        other => panic!("{other:?}"),
+    }
+    assert_eq!(load_file(&p, MAX_INDEX_BYTES + 1), Load::Unknown);
+    assert_eq!(open_failed(), Load::Unknown);
+    assert_eq!(read_failed(), Load::Unknown);
+    assert_eq!(append_failed(), Load::Unknown);
+    assert_eq!(missing_path(), Load::Unknown);
+    assert_eq!(skip_non_file(), Load::Unknown);
+    assert_eq!(too_large(), Load::Unknown);
+    assert_eq!(tree_prefix("src"), "src/");
+    assert!(contains_all(&[1, 3, 5], &[1, 5]));
+    assert!(!contains_all(&[1, 3, 5], &[2]));
+    assert!(!skip_unicode_casefold("Hello", true));
+    assert!(skip_unicode_casefold("İ", true));
+}
+
+#[cfg(unix)]
+#[test]
+fn classify_skips_symlink() {
+    let dir = tmp();
+    let target = dir.path().join("t.rs");
+    fs::write(&target, "fn target() {}\n").unwrap();
+    let link = dir.path().join("l.rs");
+    std::os::unix::fs::symlink(&target, &link).unwrap();
+    assert_eq!(classify_metadata(&link), Load::Unknown);
+}
+
+#[test]
+fn read_text_or_binary_large_and_failed_open() {
+    let dir = tmp();
+    let p = dir.path().join("wide.rs");
+    let mut f = fs::File::create(&p).unwrap();
+    let chunk = vec![b'a'; BINARY_SNIFF + 32];
+    f.write_all(&chunk).unwrap();
+    f.flush().unwrap();
+    drop(f);
+    match read_text_or_binary(&p) {
+        Load::Bytes(b) => assert_eq!(b.len(), BINARY_SNIFF + 32),
+        other => panic!("{other:?}"),
+    }
+    assert_eq!(
+        read_text_or_binary(&dir.path().join("missing.rs")),
+        Load::Unknown
+    );
+    let sniff = [b'x'; BINARY_SNIFF];
+    let mut dummy = fs::File::open(&p).unwrap();
+    assert_eq!(
+        classify_sniff(Err(std::io::Error::other("read")), &sniff, &mut dummy),
+        Load::Unknown
+    );
+    let mut buf = vec![b'a'; 3];
+    assert_eq!(
+        classify_append(
+            Err(std::io::Error::other("append")),
+            &mut buf,
+            vec![b'b'; 2]
+        ),
+        Load::Unknown
+    );
+    let mut buf = vec![b'a'; 2];
+    match classify_append(Ok(2), &mut buf, vec![b'b'; 2]) {
+        Load::Bytes(b) => assert_eq!(b, b"aabb"),
+        other => panic!("{other:?}"),
+    }
+    assert_eq!(
+        classify_sniff(Ok(0), &sniff, &mut dummy),
+        Load::Bytes(Vec::new())
+    );
+    let mut nul = [0u8; 4];
+    nul[0] = b'a';
+    nul[1] = 0;
+    assert_eq!(classify_sniff(Ok(4), &nul, &mut dummy), Load::Binary);
+}

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -5,7 +5,9 @@
 //! * **TUI file picker** — fuzzy path queries (`@file`, Ctrl+Space) served by
 //!   a resident [`nucleo`] engine; keystroke queries never touch the disk.
 //! * **File tools** — `glob` / `list` / `grep` enumerate the in-memory store
-//!   instead of re-walking the tree on every tool call.
+//!   instead of re-walking the tree on every tool call. Grep also consults
+//!   a resident content-trigram overlay so regex confirm only opens files
+//!   that could contain a required literal.
 //!
 //! The walk honours `.gitignore` / `.ignore` (via the [`ignore`] crate, the
 //! same engine ripgrep uses) plus the shared pruning [`policy`]. After the
@@ -17,6 +19,7 @@
 //! let hits = index.query("main.rs", 20);
 //! ```
 
+mod content;
 mod fuzzy;
 pub mod policy;
 mod store;
@@ -30,6 +33,9 @@ use std::sync::{Arc, Mutex, MutexGuard, RwLock, RwLockReadGuard, RwLockWriteGuar
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+pub use content::{
+    ContentIndex, MAX_INDEX_BYTES, TRIGRAM_LEN, extract_trigrams, pack_trigram, required_trigrams,
+};
 pub use fuzzy::FileMatch;
 use fuzzy::FuzzyEngine;
 pub use store::{Entry, IndexStore};
@@ -94,6 +100,7 @@ impl Default for IndexOptions {
 struct RootState {
     store: RwLock<IndexStore>,
     fuzzy: Mutex<FuzzyEngine>,
+    content: RwLock<ContentIndex>,
 }
 
 /// State shared between the public handle and the scanner thread.
@@ -150,6 +157,7 @@ impl WorkspaceIndex {
             .map(|_| RootState {
                 store: RwLock::new(IndexStore::new()),
                 fuzzy: Mutex::new(FuzzyEngine::new(results_dirty.clone())),
+                content: RwLock::new(ContentIndex::new()),
             })
             .collect();
         let (cmd_tx, cmd_rx) = mpsc::channel();
@@ -379,6 +387,45 @@ impl WorkspaceIndex {
         }
     }
 
+    /// Visit primary-root files under `search_root` that the content overlay
+    /// cannot rule out for `pattern`. `None` means "do not prune" (regex /
+    /// too short / Unicode case-fold / overlay not complete / path outside
+    /// the primary root) — the caller should fall back to [`visit`].
+    ///
+    /// `f` receives `(abs, rel, size)` with `rel` scoped to `search_root`,
+    /// matching [`visit`] + tools `visit_index`. Return `false` to stop.
+    pub fn visit_content_candidates(
+        &self,
+        search_root: &Path,
+        pattern: &str,
+        case_insensitive: bool,
+        f: &mut dyn FnMut(&Path, &str, u64) -> bool,
+    ) -> Option<()> {
+        let required = required_trigrams(pattern, case_insensitive)?;
+        let state = self.shared.states.first()?;
+        // Lock order: store → content (never reversed; see apply_changes).
+        let store = read(&state.store);
+        let content = read(&state.content);
+        if !content.is_complete() {
+            return None;
+        }
+        let root = self.shared.roots.first()?;
+        let prefix = content_search_prefix(root, search_root)?;
+        for e in store.entries() {
+            if e.is_dir || !content_entry_in_scope(&prefix, &e.rel) {
+                continue;
+            }
+            if !content.may_match(&e.rel, &required) {
+                continue;
+            }
+            let rel = content_scoped_rel(&prefix, &e.rel);
+            if !f(&root.join(&*e.rel), &rel, e.size) {
+                break;
+            }
+        }
+        Some(())
+    }
+
     /// Clone of all primary-root entries (tools that need owned data).
     pub fn entries(&self) -> Vec<Entry> {
         self.shared
@@ -415,6 +462,28 @@ impl std::fmt::Debug for WorkspaceIndex {
             .field("roots", &self.shared.roots)
             .field("status", &self.status())
             .finish()
+    }
+}
+
+fn content_search_prefix(primary: &Path, search_root: &Path) -> Option<String> {
+    let search = std::fs::canonicalize(search_root).unwrap_or_else(|_| search_root.to_path_buf());
+    let rel = search.strip_prefix(primary).ok()?;
+    let prefix = rel.to_string_lossy().replace('\\', "/");
+    Some(prefix.trim_matches('/').to_string())
+}
+
+fn content_entry_in_scope(prefix: &str, rel: &str) -> bool {
+    prefix.is_empty()
+        || (rel.len() > prefix.len()
+            && rel.starts_with(prefix)
+            && rel.as_bytes().get(prefix.len()) == Some(&b'/'))
+}
+
+fn content_scoped_rel(prefix: &str, rel: &str) -> String {
+    if prefix.is_empty() {
+        rel.to_string()
+    } else {
+        rel[prefix.len() + 1..].to_string()
     }
 }
 
@@ -512,6 +581,7 @@ fn full_scan(shared: &Arc<Shared>) {
             return;
         }
         write(&state.store).clear();
+        write(&state.content).clear();
         let injector = {
             let mut fz = lock(&state.fuzzy);
             fz.restart();
@@ -539,9 +609,15 @@ fn full_scan(shared: &Arc<Shared>) {
             },
         );
         let mut store = write(&state.store);
+        let mut content = write(&state.content);
         for e in lock(&queue).drain(..) {
+            if !e.is_dir {
+                content.upsert(&shared.roots[i], &e.rel, e.size);
+            }
             store.insert(i as u16, e.rel, e.is_dir, e.size);
         }
+        content.mark_complete();
+        drop(content);
         drop(store);
         if stats.truncated {
             shared.truncated.store(true, Ordering::Relaxed);
@@ -567,10 +643,12 @@ pub(crate) fn apply_changes(shared: &Arc<Shared>, changes: Vec<Change>) {
         let mut upserts: Vec<(Box<str>, bool)> = Vec::new();
         {
             let mut store = write(&state.store);
+            let mut content = write(&state.content);
             for c in cs {
                 match c.kind {
                     ChangeKind::Remove => {
                         store.remove_tree(root_idx, &c.rel);
+                        content.remove_tree(&c.rel);
                         saw_removal = true;
                     }
                     ChangeKind::Upsert => {
@@ -581,10 +659,16 @@ pub(crate) fn apply_changes(shared: &Arc<Shared>, changes: Vec<Change>) {
                                 let is_dir = md.is_dir();
                                 let size = if is_dir { 0 } else { md.len() };
                                 upserts.push((c.rel.clone().into_boxed_str(), is_dir));
+                                if is_dir {
+                                    content.remove(&c.rel);
+                                } else {
+                                    content.upsert(root, &c.rel, size);
+                                }
                                 store.insert(root_idx, c.rel.into_boxed_str(), is_dir, size);
                             }
                             Err(_) => {
                                 store.remove_tree(root_idx, &c.rel);
+                                content.remove_tree(&c.rel);
                                 saw_removal = true;
                             }
                         }
@@ -592,7 +676,8 @@ pub(crate) fn apply_changes(shared: &Arc<Shared>, changes: Vec<Change>) {
                 }
             }
         }
-        // Lock order is always fuzzy → store (never the reverse).
+        // Lock order is store → content, then (after drop) fuzzy → store.
+        // Never reverse either pair.
         let mut fz = lock(&state.fuzzy);
         if saw_removal {
             fz.restart();

--- a/crates/index/src/lib_tests.rs
+++ b/crates/index/src/lib_tests.rs
@@ -628,3 +628,150 @@ fn lock_helpers_survive_poison() {
     .join();
     drop(write(&store));
 }
+
+#[test]
+fn visit_content_candidates_prunes_and_scopes() {
+    let dir = fixture();
+    fs::write(dir.path().join("src/main.rs"), "fn unique_needle() {}\n").unwrap();
+    fs::write(dir.path().join("src/nested/deep.rs"), "// other\n").unwrap();
+    fs::write(dir.path().join("srcx.rs"), "fn unique_needle() {}\n").unwrap();
+    let idx = WorkspaceIndex::start_with(
+        vec![dir.path().to_path_buf()],
+        IndexOptions {
+            watch: false,
+            threads: 1,
+            ..Default::default()
+        },
+    );
+    assert!(idx.wait_ready(Duration::from_secs(10)));
+
+    let mut hits = Vec::new();
+    assert!(
+        idx.visit_content_candidates(dir.path(), "unique_needle", false, &mut |_, rel, _| {
+            hits.push(rel.to_string());
+            true
+        })
+        .is_some()
+    );
+    assert!(hits.contains(&"src/main.rs".to_string()), "{hits:?}");
+    assert!(hits.contains(&"srcx.rs".to_string()), "{hits:?}");
+    assert_eq!(hits.len(), 2, "{hits:?}");
+
+    let mut scoped = Vec::new();
+    assert!(
+        idx.visit_content_candidates(
+            &dir.path().join("src"),
+            "unique_needle",
+            false,
+            &mut |_, rel, _| {
+                scoped.push(rel.to_string());
+                true
+            }
+        )
+        .is_some()
+    );
+    assert_eq!(scoped, vec!["main.rs".to_string()]);
+    assert!(!scoped.iter().any(|r| r.contains("srcx")), "{scoped:?}");
+
+    let mut stopped = 0;
+    idx.visit_content_candidates(dir.path(), "unique_needle", false, &mut |_, _, _| {
+        stopped += 1;
+        false
+    });
+    assert_eq!(stopped, 1);
+
+    assert!(
+        idx.visit_content_candidates(dir.path(), "unique.needle", false, &mut |_, _, _| true)
+            .is_none(),
+        "regex must not prune"
+    );
+    assert!(
+        idx.visit_content_candidates(dir.path(), "ab", false, &mut |_, _, _| true)
+            .is_none()
+    );
+    assert!(
+        idx.visit_content_candidates(
+            Path::new("/no/such/grep/root"),
+            "unique_needle",
+            false,
+            &mut |_, _, _| true
+        )
+        .is_none()
+    );
+
+    let empty = WorkspaceIndex::start_with(vec![], IndexOptions::default());
+    assert!(
+        empty
+            .visit_content_candidates(Path::new("."), "unique_needle", false, &mut |_, _, _| true)
+            .is_none()
+    );
+}
+
+#[test]
+fn visit_content_candidates_incomplete_when_truncated_empty() {
+    let dir = fixture();
+    let idx = WorkspaceIndex::start_with(
+        vec![dir.path().to_path_buf()],
+        IndexOptions {
+            watch: false,
+            max_entries: 0,
+            threads: 1,
+        },
+    );
+    assert!(idx.wait_ready(Duration::from_secs(10)));
+    assert!(
+        idx.visit_content_candidates(dir.path(), "unique_needle", false, &mut |_, _, _| true)
+            .is_none()
+    );
+}
+
+#[test]
+fn apply_changes_updates_content_overlay() {
+    let dir = fixture();
+    let idx = WorkspaceIndex::start_with(
+        vec![dir.path().to_path_buf()],
+        IndexOptions {
+            watch: false,
+            threads: 1,
+            ..Default::default()
+        },
+    );
+    assert!(idx.wait_ready(Duration::from_secs(10)));
+    fs::write(dir.path().join("src/extra.rs"), "fn extra_unique() {}\n").unwrap();
+    idx.apply_test_changes(vec![Change {
+        root: 0,
+        rel: "src/extra.rs".into(),
+        kind: ChangeKind::Upsert,
+    }]);
+    let mut hits = Vec::new();
+    idx.visit_content_candidates(dir.path(), "extra_unique", false, &mut |_, rel, _| {
+        hits.push(rel.to_string());
+        true
+    });
+    assert_eq!(hits, vec!["src/extra.rs".to_string()]);
+
+    fs::remove_file(dir.path().join("src/extra.rs")).unwrap();
+    idx.apply_test_changes(vec![Change {
+        root: 0,
+        rel: "src/extra.rs".into(),
+        kind: ChangeKind::Remove,
+    }]);
+    hits.clear();
+    idx.visit_content_candidates(dir.path(), "extra_unique", false, &mut |_, rel, _| {
+        hits.push(rel.to_string());
+        true
+    });
+    assert!(hits.is_empty(), "{hits:?}");
+
+    idx.apply_test_changes(vec![Change {
+        root: 0,
+        rel: "src".into(),
+        kind: ChangeKind::Upsert,
+    }]);
+    hits.clear();
+    idx.visit_content_candidates(dir.path(), "fn main", false, &mut |_, rel, _| {
+        hits.push(rel.to_string());
+        true
+    });
+    assert!(hits.iter().any(|r| r == "src/main.rs"), "{hits:?}");
+}

--- a/crates/sdk/src/client.rs
+++ b/crates/sdk/src/client.rs
@@ -116,11 +116,7 @@ impl WhyCodesClient {
         // `bind(127.0.0.1:0)` then drop the listener before spawn. A sibling
         // launch can steal that port (EADDRINUSE). Retry only when we picked
         // the port; an explicit `opts.port` must fail on collision.
-        let attempts = if opts.port.is_none() {
-            EPHEMERAL_PORT_RETRIES
-        } else {
-            1
-        };
+        let attempts = ephemeral_launch_attempts(opts.port.is_some());
         let mut last_err = None;
         for attempt in 0..attempts {
             let prepared = prepare_launch(&opts)?;
@@ -161,7 +157,7 @@ impl WhyCodesClient {
                     LaunchPoll::Failed(err) => {
                         let stderr = take_stderr(&mut client.child).await;
                         let err = attach_stderr(err, &stderr);
-                        if attempt + 1 < attempts && port_in_use_stderr(&stderr) {
+                        if should_retry_ephemeral_port(attempt, attempts, &stderr) {
                             last_err = Some(err);
                             break;
                         }
@@ -170,9 +166,7 @@ impl WhyCodesClient {
                 }
             }
         }
-        Err(last_err.unwrap_or_else(|| {
-            SdkError::new(ErrorCode::StartupFailed, "ephemeral port retries exhausted")
-        }))
+        Err(exhausted_ephemeral_port_error(last_err))
     }
 
     /// Daemon base URL (`http://127.0.0.1:3030`).
@@ -813,6 +807,24 @@ fn ephemeral_addr_failed(e: std::io::Error) -> SdkError {
 }
 
 const EPHEMERAL_PORT_RETRIES: u32 = 8;
+
+fn ephemeral_launch_attempts(explicit_port: bool) -> u32 {
+    if explicit_port {
+        1
+    } else {
+        EPHEMERAL_PORT_RETRIES
+    }
+}
+
+fn should_retry_ephemeral_port(attempt: u32, attempts: u32, stderr: &str) -> bool {
+    attempt + 1 < attempts && port_in_use_stderr(stderr)
+}
+
+fn exhausted_ephemeral_port_error(last: Option<SdkError>) -> SdkError {
+    last.unwrap_or_else(|| {
+        SdkError::new(ErrorCode::StartupFailed, "ephemeral port retries exhausted")
+    })
+}
 
 fn ephemeral_port() -> Result<u16, SdkError> {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").map_err(ephemeral_bind_failed)?;

--- a/crates/sdk/src/client.rs
+++ b/crates/sdk/src/client.rs
@@ -113,47 +113,66 @@ impl WhyCodesClient {
         if let Some(err) = missing_spawned_binary(&binary) {
             return Err(err);
         }
-        let prepared = prepare_launch(&opts)?;
-        let mut cmd = launch_command(&prepared, &opts);
-        let child = cmd.spawn().map_err(|e| {
-            SdkError::with_source(
-                ErrorCode::ServeNotFound,
-                &format!("could not execute {}: {e}", prepared.binary.display()),
-                e,
-            )
-        })?;
-        let port = prepared.port;
-        let held_home = prepared.held_home;
-
-        let base = format!("http://127.0.0.1:{port}");
-        let http = http_client()?;
-        let mut client = Self {
-            base: base.clone(),
-            http,
-            child: Some(child),
-            _home: held_home,
+        // `bind(127.0.0.1:0)` then drop the listener before spawn. A sibling
+        // launch can steal that port (EADDRINUSE). Retry only when we picked
+        // the port; an explicit `opts.port` must fail on collision.
+        let attempts = if opts.port.is_none() {
+            EPHEMERAL_PORT_RETRIES
+        } else {
+            1
         };
+        let mut last_err = None;
+        for attempt in 0..attempts {
+            let prepared = prepare_launch(&opts)?;
+            let mut cmd = launch_command(&prepared, &opts);
+            let child = cmd.spawn().map_err(|e| {
+                SdkError::with_source(
+                    ErrorCode::ServeNotFound,
+                    &format!("could not execute {}: {e}", prepared.binary.display()),
+                    e,
+                )
+            })?;
+            let port = prepared.port;
+            let held_home = prepared.held_home;
 
-        let deadline = Instant::now() + opts.startup_timeout;
-        loop {
-            let child_status = poll_child_exit(client.child.as_mut());
-            let handshake = client.handshake().await.map(|_| ());
-            match launch_poll(
-                Instant::now(),
-                deadline,
-                opts.startup_timeout,
-                &base,
-                child_status,
-                handshake,
-            ) {
-                LaunchPoll::Ready => return Ok(client),
-                LaunchPoll::Retry => tokio::time::sleep(Duration::from_millis(50)).await,
-                LaunchPoll::Failed(err) => {
-                    let stderr = take_stderr(&mut client.child).await;
-                    return Err(attach_stderr(err, &stderr));
+            let base = format!("http://127.0.0.1:{port}");
+            let http = http_client()?;
+            let mut client = Self {
+                base: base.clone(),
+                http,
+                child: Some(child),
+                _home: held_home,
+            };
+
+            let deadline = Instant::now() + opts.startup_timeout;
+            loop {
+                let child_status = poll_child_exit(client.child.as_mut());
+                let handshake = client.handshake().await.map(|_| ());
+                match launch_poll(
+                    Instant::now(),
+                    deadline,
+                    opts.startup_timeout,
+                    &base,
+                    child_status,
+                    handshake,
+                ) {
+                    LaunchPoll::Ready => return Ok(client),
+                    LaunchPoll::Retry => tokio::time::sleep(Duration::from_millis(50)).await,
+                    LaunchPoll::Failed(err) => {
+                        let stderr = take_stderr(&mut client.child).await;
+                        let err = attach_stderr(err, &stderr);
+                        if attempt + 1 < attempts && port_in_use_stderr(&stderr) {
+                            last_err = Some(err);
+                            break;
+                        }
+                        return Err(err);
+                    }
                 }
             }
         }
+        Err(last_err.unwrap_or_else(|| {
+            SdkError::new(ErrorCode::StartupFailed, "ephemeral port retries exhausted")
+        }))
     }
 
     /// Daemon base URL (`http://127.0.0.1:3030`).
@@ -793,12 +812,21 @@ fn ephemeral_addr_failed(e: std::io::Error) -> SdkError {
     SdkError::with_source(ErrorCode::StartupFailed, "ephemeral port", e)
 }
 
+const EPHEMERAL_PORT_RETRIES: u32 = 8;
+
 fn ephemeral_port() -> Result<u16, SdkError> {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").map_err(ephemeral_bind_failed)?;
     listener
         .local_addr()
         .map(|a| a.port())
         .map_err(ephemeral_addr_failed)
+}
+
+fn port_in_use_stderr(stderr: &str) -> bool {
+    let s = stderr.to_ascii_lowercase();
+    s.contains("address already in use")
+        || s.contains("eaddrinuse")
+        || s.contains("only one usage of each socket address")
 }
 
 const STRIPPED_LOGIN_KEYS: &[&str] = &[

--- a/crates/sdk/src/client_tests.rs
+++ b/crates/sdk/src/client_tests.rs
@@ -101,6 +101,30 @@ fn port_in_use_stderr_matches_unix_and_windows() {
 }
 
 #[test]
+fn ephemeral_retry_helpers() {
+    assert_eq!(ephemeral_launch_attempts(true), 1);
+    assert_eq!(ephemeral_launch_attempts(false), EPHEMERAL_PORT_RETRIES);
+    assert!(should_retry_ephemeral_port(
+        0,
+        8,
+        "OSError: [Errno 98] Address already in use"
+    ));
+    assert!(!should_retry_ephemeral_port(
+        7,
+        8,
+        "OSError: [Errno 98] Address already in use"
+    ));
+    assert!(!should_retry_ephemeral_port(0, 8, "connection refused"));
+    assert!(!should_retry_ephemeral_port(0, 1, "Address already in use"));
+    let exhausted = exhausted_ephemeral_port_error(None);
+    assert_eq!(exhausted.code, ErrorCode::StartupFailed);
+    assert!(exhausted.message.contains("retries exhausted"));
+    let prior = SdkError::new(ErrorCode::StartupFailed, "port busy");
+    let wrapped = exhausted_ephemeral_port_error(Some(prior));
+    assert_eq!(wrapped.message, "port busy");
+}
+
+#[test]
 fn launch_options_default() {
     let o = LaunchOptions::default();
     assert!(o.inherit_logins);
@@ -840,6 +864,51 @@ HTTPServer(("127.0.0.1", port), H).serve_forever()
     .unwrap();
 }
 
+fn write_eaddrinuse_then_health_script(dir: &std::path::Path, protocol: u32) {
+    std::fs::write(
+        dir.join("serve"),
+        format!(
+            r#"
+import json, os, sys
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+marker = os.path.join(os.getcwd(), ".eaddrinuse-once")
+if not os.path.exists(marker):
+    open(marker, "w").close()
+    sys.stderr.write("OSError: [Errno 98] Address already in use\n")
+    sys.stderr.flush()
+    sys.exit(1)
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/v1/health":
+            body = json.dumps({{
+                "protocol": {protocol},
+                "version": "0.0.0",
+                "healthy": True,
+                "project": "/tmp",
+                "uptime_secs": 1,
+                "sessions_in_memory": 0,
+            }}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+    def log_message(self, *_args):
+        pass
+
+port = int(sys.argv[-1])
+HTTPServer(("127.0.0.1", port), H).serve_forever()
+"#
+        ),
+    )
+    .unwrap();
+}
+
 /// Real spawn + handshake Ready path: `python3 serve <port>` binds
 /// `/v1/health` on the requested port.
 #[tokio::test]
@@ -856,6 +925,26 @@ async fn launch_python_health_server_is_ready() {
     })
     .await
     .expect("python health server should become ready");
+    assert!(client.base_url().starts_with("http://127.0.0.1:"));
+    client.close().await.unwrap();
+}
+
+/// First spawn prints EADDRINUSE and exits; launch retries and the second
+/// spawn serves `/v1/health`.
+#[tokio::test]
+async fn launch_retries_when_ephemeral_port_is_stolen() {
+    let dir = tempfile::tempdir().unwrap();
+    write_eaddrinuse_then_health_script(dir.path(), PROTOCOL_MAJOR);
+    let client = WhyCodesClient::launch(LaunchOptions {
+        working_dir: dir.path().to_path_buf(),
+        binary: Some(python3()),
+        inherit_logins: false,
+        startup_timeout: Duration::from_secs(5),
+        port: None,
+        home: None,
+    })
+    .await
+    .expect("launch should retry after EADDRINUSE");
     assert!(client.base_url().starts_with("http://127.0.0.1:"));
     client.close().await.unwrap();
 }

--- a/crates/sdk/src/client_tests.rs
+++ b/crates/sdk/src/client_tests.rs
@@ -89,6 +89,18 @@ fn ephemeral_port_binds() {
 }
 
 #[test]
+fn port_in_use_stderr_matches_unix_and_windows() {
+    assert!(port_in_use_stderr(
+        "OSError: [Errno 98] Address already in use"
+    ));
+    assert!(port_in_use_stderr("bind: EADDRINUSE"));
+    assert!(port_in_use_stderr(
+        "Only one usage of each socket address is normally permitted"
+    ));
+    assert!(!port_in_use_stderr("connection refused"));
+}
+
+#[test]
 fn launch_options_default() {
     let o = LaunchOptions::default();
     assert!(o.inherit_logins);

--- a/crates/tools/src/file/grep.rs
+++ b/crates/tools/src/file/grep.rs
@@ -35,6 +35,7 @@ impl Tool for GrepTool {
     fn description(&self) -> &str {
         "Search file contents with regex (ripgrep engine, in-process — no `rg` binary). \
          Respects .gitignore; skips binaries and heavy dirs (target, node_modules, .git, …). \
+         Literal queries prune files via the workspace content index before scanning. \
          Prefer over shell grep for project code search. Hits are \
          `path:line tag:text` so `edit` can name the line by tag."
     }
@@ -195,13 +196,7 @@ impl GrepTool {
             let used_index = if targets_hidden {
                 false
             } else if let Some(idx) = file_index {
-                visit_index(idx, path, &mut |file, rel, is_dir, _size| {
-                    if is_dir {
-                        return true;
-                    }
-                    collect(file, rel)
-                })
-                .is_some()
+                collect_from_index(idx, path, pattern, case_insensitive, &mut collect)
             } else {
                 false
             };
@@ -342,6 +337,30 @@ impl Sink for CollectSink<'_> {
     fn context_break(&mut self, _searcher: &grep_searcher::Searcher) -> Result<bool, Self::Error> {
         sink_context_break(self.matches, self.max_results)
     }
+}
+
+fn collect_from_index(
+    idx: &whycodes_index::WorkspaceIndex,
+    path: &Path,
+    pattern: &str,
+    case_insensitive: bool,
+    collect: &mut dyn FnMut(&Path, &str) -> bool,
+) -> bool {
+    if idx
+        .visit_content_candidates(path, pattern, case_insensitive, &mut |file, rel, _size| {
+            collect(file, rel)
+        })
+        .is_some()
+    {
+        return true;
+    }
+    visit_index(idx, path, &mut |file, rel, is_dir, _size| {
+        if is_dir {
+            return true;
+        }
+        collect(file, rel)
+    })
+    .is_some()
 }
 
 fn grep_file_task(

--- a/crates/tools/src/file/grep_tests.rs
+++ b/crates/tools/src/file/grep_tests.rs
@@ -411,3 +411,69 @@ async fn search_uses_index_hidden_glob_and_truncates() {
         .await;
     assert!(!with_ctx.is_error, "{}", with_ctx.content);
 }
+
+#[test]
+fn search_index_prunes_files_without_trigrams() {
+    use std::time::Duration;
+    use whycodes_index::IndexOptions;
+    let dir = TempDir::new().unwrap();
+    fs::create_dir_all(dir.path().join("src")).unwrap();
+    write(&dir, "src/hit.rs", "fn unique_needle() {}\n");
+    write(&dir, "src/miss.rs", "fn other() {}\n");
+    write(&dir, "src/Case.rs", "HelloWorld\n");
+    write(&dir, "README.md", "unique_needle in docs\n");
+    let idx = whycodes_index::WorkspaceIndex::start_with(
+        vec![dir.path().to_path_buf()],
+        IndexOptions {
+            watch: false,
+            threads: 1,
+            ..Default::default()
+        },
+    );
+    assert!(idx.wait_ready(Duration::from_secs(10)));
+
+    let out = GrepTool::search(
+        "unique_needle",
+        dir.path(),
+        None,
+        false,
+        0,
+        50,
+        dir.path().to_str().unwrap(),
+        Some(&idx),
+    )
+    .unwrap();
+    assert!(out.contains("src/hit.rs"), "{out}");
+    assert!(out.contains("README.md"), "{out}");
+    assert!(!out.contains("src/miss.rs"), "{out}");
+    assert!(out.contains("in 2 file"), "{out}");
+
+    let regex = GrepTool::search(
+        "unique.needle",
+        dir.path(),
+        None,
+        false,
+        0,
+        50,
+        dir.path().to_str().unwrap(),
+        Some(&idx),
+    )
+    .unwrap();
+    assert!(regex.contains("src/hit.rs"), "{regex}");
+    assert!(regex.contains("README.md"), "{regex}");
+    assert!(regex.contains("in 4 file"), "{regex}");
+
+    let ci = GrepTool::search(
+        "helloworld",
+        dir.path(),
+        Some("*.rs"),
+        true,
+        0,
+        50,
+        dir.path().to_str().unwrap(),
+        Some(&idx),
+    )
+    .unwrap();
+    assert!(ci.contains("src/Case.rs"), "{ci}");
+    assert!(ci.contains("in 1 file"), "{ci}");
+}

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2366,6 +2366,20 @@ Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs al
 
 **Prevention:** Tests that share `LlmTransport::complete` must not reuse prompt+model across success and error cases.
 
+## SDK launch: ephemeral port stolen before spawn
+
+**Date:** 2026-09-12 · **Area:** `crates/sdk/src/client.rs`
+
+**Symptom:** `client::tests::launch_python_health_server_is_ready` failed on Linux CI with `OSError: [Errno 98] Address already in use` while `launch_python_wrong_protocol_is_unsupported_version` passed in the same crate.
+
+**JSONL / crash:** none.
+
+**Root cause:** `ephemeral_port()` binds `127.0.0.1:0` then drops the listener. A sibling `launch(..., port: None)` can pick the same number before `python serve` binds. Parallel SDK tests on one host hit that window.
+
+**Fix:** When `LaunchOptions.port` is `None`, retry spawn on a fresh ephemeral port if child stderr looks like EADDRINUSE (unix + Windows wording). An explicit port still fails on collision.
+
+**Prevention:** Do not treat `bind(:0)` + drop as a reservation. Retry or hold the socket until the child is ready to inherit it.
+
 ## Coverage flake: `git::commit::tests::commit_module_loads` cannot spawn `false`
 
 **Date:** 2026-09-12 · **Area:** `crates/tools/src/git/commit_tests.rs`

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2006,8 +2006,9 @@ prompt (or Ctrl+Space) opens the picker; dirs drill down on Tab.
   highlight positions (cheap at picker sizes).
 - Injector pushes are thread-safe and stream during the walk; `restart()`
   is the only way to remove items.
-- Lock order is **fuzzy → store**, never reversed (delta application takes
-  both); queries lock only fuzzy, browse/tools lock only store.
+- Lock order is **store → content**, then (after drop) **fuzzy → store**.
+  Never reverse either pair. Queries lock only fuzzy; browse/tools lock
+  only store; grep prune locks store then content.
 - The scanner thread must NOT hold an `Arc` cycle: split `WorkspaceIndex`
   (handle, owns `JoinHandle`) from `Shared` (thread's `Arc` target), or the
   last external drop never runs.
@@ -2378,3 +2379,20 @@ Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs al
 **Fix:** Build the failing `ExitStatus` with `ExitStatusExt::from_raw` (unix wait status `1 << 8`, Windows `1`). Same for the browser test helpers.
 
 **Prevention:** Helpers that only need a dummy `ExitStatus` must not spawn PATH binaries. Tests that mutate `PATH` already hold `ENV_LOCK`; unlocked tests must not depend on PATH.
+
+## Content trigrams prune grep; they must not hide matches
+
+**Date:** 2026-09-12 · **Area:** `crates/index` content overlay + `tools` grep
+
+**Symptom:** A resident path index still made every grep scan every file. Microsoft tgrep's answer is a trigram inverted index. We did **not** take their CLI or git crate (`deny.toml` `unknown-git = deny`).
+
+**What shipped:** In-memory per-root overlay in `WorkspaceIndex`. Literal patterns (≥3 bytes, no regex meta) prune files that lack a required trigram; `grep-searcher` still confirms. Regex / short / Unicode-casefold / incomplete overlay → no prune.
+
+**Pitfalls:**
+
+- Overlay lock order is **store → content**, then (after drop) **fuzzy → store**. Never hold fuzzy and content together.
+- Unknown paths (`may_match` with no posting) must return **true**. A partial overlay that drops unknowns hides matches.
+- Files larger than the overlay cap (1 MiB) stay **unknown**, not skipped. Grep still searches them up to 2 MiB.
+- Index original-case trigrams **union** ASCII-lowercased ones. Lowercase-only storage false-negatives a case-sensitive `Hello` against file `Hello`.
+- Do not prune on Unicode case-insensitive queries (`İ` / `ı`). ASCII `i` is the only fold the overlay applies.
+- `visit_content_candidates` `rel` is scoped to the search root, same contract as tools `visit_index`.


### PR DESCRIPTION
## What

Literal `grep` queries now skip files that cannot contain a required 3-byte trigram, using a resident overlay on `WorkspaceIndex`. Regex confirm still uses `grep-searcher`.

## Why

Microsoft tgrep (Copilot CLI) pre-filters with a trigram index so large-repo greps do not scan every file. WhyCodes already had a path index + in-process ripgrep; content search still opened every candidate. This takes the tgrep idea in-process: no CLI, no git crate (`deny.toml` unknown-git = deny), no TCP server.

Regex, short patterns, Unicode case-fold, incomplete overlays, and files larger than 1 MiB fall back to the existing full scan so the overlay cannot hide matches.

## Checks

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p whycodes-index --all-targets -- -D warnings` and `cargo clippy -p whycodes-tools --features bundled-sqlite --all-targets -- -D warnings`
- [x] `cargo test -p whycodes-index --lib` and `cargo test -p whycodes-tools --features bundled-sqlite --lib grep`
- [x] Budget scripts (`check_panic_budget.py`, `check_swallowed_error_budget.py`, `check_dependency_boundaries.py`, `check_tracked_secrets.py`)
- [ ] TypeScript SDK tests if you changed `crates/protocol/src/sdk.rs` or `sdk/typescript` (n/a)