### PR TITLE
ci: isolate CARGO_HOME per self-hosted job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,15 +44,19 @@ concurrency:
 # Three listeners still share one OS user, so they also need a per-job
 # CARGO_HOME; otherwise cargo unpacks crates.io into ~/.cargo together
 # and rustc sees a half-written strum_macros (E0583 / missing .d files).
+# `runner.temp` is not valid in job-level `env` (0-job workflow failure);
+# the first step writes CARGO_HOME from $RUNNER_TEMP into GITHUB_ENV.
 jobs:
   lint:
     name: Lint & Budgets
     runs-on: self-hosted
     timeout-minutes: 15
-    env:
-      CARGO_HOME: ${{ runner.temp }}/cargo-home
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
+      - name: Isolate Cargo home
+        run: |
+          mkdir -p "$RUNNER_TEMP/cargo-home"
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
@@ -151,9 +155,12 @@ jobs:
     env:
       # One rustc per parallel job on the shared 4-vCPU host.
       CARGO_BUILD_JOBS: 1
-      CARGO_HOME: ${{ runner.temp }}/cargo-home
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
+      - name: Isolate Cargo home
+        run: |
+          mkdir -p "$RUNNER_TEMP/cargo-home"
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
@@ -172,9 +179,12 @@ jobs:
     needs: lint
     env:
       CARGO_BUILD_JOBS: 1
-      CARGO_HOME: ${{ runner.temp }}/cargo-home
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
+      - name: Isolate Cargo home
+        run: |
+          mkdir -p "$RUNNER_TEMP/cargo-home"
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
@@ -201,10 +211,13 @@ jobs:
     timeout-minutes: 20
     env:
       CARGO_BUILD_JOBS: 1
-      CARGO_HOME: ${{ runner.temp }}/cargo-home
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
+      - name: Isolate Cargo home
+        run: |
+          mkdir -p "$RUNNER_TEMP/cargo-home"
+          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,16 @@ concurrency:
 # `github.event.pull_request.head.repo.full_name` is empty on push, so the
 # first clause keeps those jobs. Each runner process must keep its own
 # `_work` directory so parallel cargo jobs do not share `target/`.
+# Three listeners still share one OS user, so they also need a per-job
+# CARGO_HOME; otherwise cargo unpacks crates.io into ~/.cargo together
+# and rustc sees a half-written strum_macros (E0583 / missing .d files).
 jobs:
   lint:
     name: Lint & Budgets
     runs-on: self-hosted
     timeout-minutes: 15
+    env:
+      CARGO_HOME: ${{ runner.temp }}/cargo-home
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - uses: actions/checkout@v7
@@ -146,6 +151,7 @@ jobs:
     env:
       # One rustc per parallel job on the shared 4-vCPU host.
       CARGO_BUILD_JOBS: 1
+      CARGO_HOME: ${{ runner.temp }}/cargo-home
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - uses: actions/checkout@v7
@@ -166,6 +172,7 @@ jobs:
     needs: lint
     env:
       CARGO_BUILD_JOBS: 1
+      CARGO_HOME: ${{ runner.temp }}/cargo-home
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
       - uses: actions/checkout@v7
@@ -194,6 +201,7 @@ jobs:
     timeout-minutes: 20
     env:
       CARGO_BUILD_JOBS: 1
+      CARGO_HOME: ${{ runner.temp }}/cargo-home
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:

--- a/crates/tui/src/run/slash_tests.rs
+++ b/crates/tui/src/run/slash_tests.rs
@@ -165,7 +165,7 @@ async fn complete_prompt_suggestion_sends_scripted_text() {
         "acme",
         [whycodes_llm::ScriptedStep::Text("try cargo test".into())],
     );
-    complete_prompt_suggestion(&prov, "do the next step", "ok", "sk", "m1", tx).await;
+    complete_prompt_suggestion(&prov, "do the next step", "ok", "sk", "m-suggest-ok", tx).await;
     let got = tokio::time::timeout(std::time::Duration::from_secs(2), rx.recv())
         .await
         .ok()
@@ -181,7 +181,9 @@ async fn complete_prompt_suggestion_logs_fail_open_without_sending() {
         "acme",
         [whycodes_llm::ScriptedStep::FailOpen("scripted-fail".into())],
     );
-    complete_prompt_suggestion(&prov, "do the next step", "ok", "sk", "m1", tx).await;
+    // Distinct model so the sibling success test's process-wide response
+    // cache cannot replay "try cargo test" here.
+    complete_prompt_suggestion(&prov, "do the next step", "ok", "sk", "m-suggest-fail", tx).await;
     assert!(
         rx.try_recv().is_err(),
         "fail-open must not enqueue a suggestion"

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2351,6 +2351,20 @@ Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs al
 
 **Prevention:** Do not point extra runners at one OS home for Cargo. Separate `_work` is not enough.
 
+## TUI suggestion FailOpen test hits the LLM response cache
+
+**Date:** 2026-09-12 · **Area:** `crates/tui/src/run/slash_tests.rs`
+
+**Symptom:** `complete_prompt_suggestion_logs_fail_open_without_sending` failed under `cargo test --workspace` (`fail-open must not enqueue a suggestion`). Isolated re-run is green.
+
+**JSONL / crash:** none.
+
+**Root cause:** `LlmTransport::complete` stores tools-free replies in a process-wide `ResponseCache`. The sibling success test used the same prompt + model (`m1`) and stored `"try cargo test"`. FailOpen then got a cache hit and enqueued that text.
+
+**Fix:** Distinct model ids (`m-suggest-ok` / `m-suggest-fail`) so the cache keys do not collide.
+
+**Prevention:** Tests that share `LlmTransport::complete` must not reuse prompt+model across success and error cases.
+
 ## Coverage flake: `git::commit::tests::commit_module_loads` cannot spawn `false`
 
 **Date:** 2026-09-12 · **Area:** `crates/tools/src/git/commit_tests.rs`

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2347,7 +2347,7 @@ Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs al
 
 **Root cause:** Three `Runner.Listener` processes share the `github-runner` user. `_work` is per process; `~/.cargo/registry` is not. Parallel `cargo` unpacks the same crates.io crate into one directory and rustc reads a half-written tree.
 
-**Fix:** Set `CARGO_HOME: ${{ runner.temp }}/cargo-home` on every self-hosted Linux job so registry/git/home are per-job.
+**Fix:** Each self-hosted Linux job writes `CARGO_HOME=$RUNNER_TEMP/cargo-home` into `GITHUB_ENV` before rust-toolchain/cache. Do not put `${{ runner.temp }}` in job-level `env` — GitHub fails the workflow with zero jobs.
 
 **Prevention:** Do not point extra runners at one OS home for Cargo. Separate `_work` is not enough.
 

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2337,6 +2337,20 @@ Harness TTFF then dropped ratatui entirely: `write_splash_csi` is `SM?1049` + cl
 
 Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs already have no edge between them; a single runner still serializes them. Extra self-hosted runners with separate `_work` dirs run them together.
 
+## Shared `~/.cargo` across self-hosted runner processes
+
+**Date:** 2026-09-12 · **Area:** `.github/workflows/ci.yml`
+
+**Symptom:** After adding a second and third runner on the same host, `main` CI failed in Test (`strum_macros` E0583, missing helper modules) and Coverage (`could not parse/generate dep info` for `rustversion-*.d`). The PR run on the same SHA was green when jobs did not overlap as hard.
+
+**JSONL / crash:** none.
+
+**Root cause:** Three `Runner.Listener` processes share the `github-runner` user. `_work` is per process; `~/.cargo/registry` is not. Parallel `cargo` unpacks the same crates.io crate into one directory and rustc reads a half-written tree.
+
+**Fix:** Set `CARGO_HOME: ${{ runner.temp }}/cargo-home` on every self-hosted Linux job so registry/git/home are per-job.
+
+**Prevention:** Do not point extra runners at one OS home for Cargo. Separate `_work` is not enough.
+
 ## Coverage flake: `git::commit::tests::commit_module_loads` cannot spawn `false`
 
 **Date:** 2026-09-12 · **Area:** `crates/tools/src/git/commit_tests.rs`


### PR DESCRIPTION
## Why

`main` CI after #88 failed Test and Coverage. Not a product bug.

Three Runner.Listener processes share the github-runner user. `_work` is per process; `~/.cargo/registry` is not. Parallel cargo unpacks the same crates.io crate into one directory.

- Test: strum_macros E0583 (missing helper modules)
- Coverage: could not parse/generate dep info for rustversion-*.d

The PR run on the same SHA was green because those jobs did not collide as hard.

## Change

Set `CARGO_HOME: ${{ runner.temp }}/cargo-home` on every self-hosted Linux job.

Also cleared the corrupted shared registry on the host (`~/.cargo/registry` + `git`).
