### PR TITLE
ci: persist isolated Cargo home and target per runner job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,14 @@ concurrency:
 # `github.event.pull_request.head.repo.full_name` is empty on push, so the
 # first clause keeps those jobs. Each runner process must keep its own
 # `_work` directory so parallel cargo jobs do not share `target/`.
-# Three listeners still share one OS user, so they also need a per-job
-# CARGO_HOME; otherwise cargo unpacks crates.io into ~/.cargo together
-# and rustc sees a half-written strum_macros (E0583 / missing .d files).
-# `runner.temp` is not valid in job-level `env` (0-job workflow failure);
-# the first step writes CARGO_HOME from $RUNNER_TEMP into GITHUB_ENV.
+# Three listeners share one OS user. Per-job CARGO_HOME + CARGO_TARGET_DIR
+# live under RUNNER_TOOL_CACHE/<runner>/<job> (not ~/.cargo, not
+# RUNNER_TEMP, not the git worktree). `actions/checkout` `git clean -ffdx`
+# would wipe workspace `target/`; a temp home forced a cold crates.io
+# unpack every job. Disk persistence is the hot path; rust-cache only
+# seeds registry/git when that disk is empty (and never restores into a
+# populated home — that clobber is how strum_macros E0583 happened).
+# Do not put `${{ runner.temp }}` in job-level `env` (0-job failure).
 jobs:
   lint:
     name: Lint & Budgets
@@ -53,20 +56,19 @@ jobs:
     timeout-minutes: 15
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
-      - name: Isolate Cargo home
-        run: |
-          mkdir -p "$RUNNER_TEMP/cargo-home"
-          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Isolate Cargo home
+        run: sh scripts/ci_isolate_cargo_home.sh
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
+        if: env.CARGO_CACHE_HIT_LOCAL != '1'
         with:
-          # Shared key so every Linux job restores the same cargo cache.
-          shared-key: whycodes-ci
+          shared-key: whycodes-ci-registry
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: actions/setup-node@v7
         with:
@@ -104,11 +106,14 @@ jobs:
           sh -n scripts/tui_term_matrix.sh
           sh -n scripts/coverage.sh
           test -x scripts/coverage.sh
+          sh -n scripts/ci_isolate_cargo_home.sh
+          test -x scripts/ci_isolate_cargo_home.sh
           sh -n scripts/pre-push
           sh -n scripts/install_git_hooks.sh
           sh scripts/test_update_homebrew_formula.sh
           sh scripts/test_tui_term_matrix.sh
           sh scripts/test_coverage.sh
+          sh scripts/test_ci_isolate_cargo_home.sh
           sh scripts/test_pre_push.sh
           python scripts/test_tracked_secrets.py
           python scripts/test_release_downloads.py
@@ -157,17 +162,17 @@ jobs:
       CARGO_BUILD_JOBS: 1
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
-      - name: Isolate Cargo home
-        run: |
-          mkdir -p "$RUNNER_TEMP/cargo-home"
-          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Isolate Cargo home
+        run: sh scripts/ci_isolate_cargo_home.sh
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        if: env.CARGO_CACHE_HIT_LOCAL != '1'
         with:
-          shared-key: whycodes-ci
+          shared-key: whycodes-ci-registry
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run tests
         run: cargo test --workspace --locked --features whycodes-storage/bundled
@@ -181,19 +186,19 @@ jobs:
       CARGO_BUILD_JOBS: 1
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
-      - name: Isolate Cargo home
-        run: |
-          mkdir -p "$RUNNER_TEMP/cargo-home"
-          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Isolate Cargo home
+        run: sh scripts/ci_isolate_cargo_home.sh
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+        if: env.CARGO_CACHE_HIT_LOCAL != '1'
         with:
-          shared-key: whycodes-ci
+          shared-key: whycodes-ci-registry
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - uses: taiki-e/install-action@v2
         with:
@@ -214,17 +219,17 @@ jobs:
     needs: lint
     if: ${{ always() && needs.lint.result == 'success' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     steps:
-      - name: Isolate Cargo home
-        run: |
-          mkdir -p "$RUNNER_TEMP/cargo-home"
-          echo "CARGO_HOME=$RUNNER_TEMP/cargo-home" >> "$GITHUB_ENV"
       - uses: actions/checkout@v7
         with:
           fetch-depth: 1
+      - name: Isolate Cargo home
+        run: sh scripts/ci_isolate_cargo_home.sh
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+        if: env.CARGO_CACHE_HIT_LOCAL != '1'
         with:
-          shared-key: whycodes-ci
+          shared-key: whycodes-ci-registry
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build release (cli only — workspace builds 2 extra crates not in the shipped binary)
         run: cargo build --release --locked -p whycodes-cli --features bundled-sqlite
@@ -233,7 +238,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: whycodes-linux
-          path: target/release/whycodes*
+          path: ${{ env.CARGO_TARGET_DIR }}/release/whycodes*
           retention-days: 3
 
   # Public forks never reach the self-hosted jobs above. This GitHub-hosted

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ Things to know about CI:
   same-repo branch. A new push to the same PR or to `main` cancels the
   previous CI run so the pool is not stuck on stale jobs. After lint, Test /
   Coverage / Build run in parallel across whatever runners are online.
+  Each job pins `CARGO_HOME` and `CARGO_TARGET_DIR` under
+  `RUNNER_TOOL_CACHE/<runner>/<job>` so crates.io and `target/` survive
+  `git clean` without sharing `~/.cargo` across listeners. GitHub
+  `rust-cache` only seeds the registry when that disk is empty.
 
 ## Conventions
 

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2347,9 +2347,9 @@ Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs al
 
 **Root cause:** Three `Runner.Listener` processes share the `github-runner` user. `_work` is per process; `~/.cargo/registry` is not. Parallel `cargo` unpacks the same crates.io crate into one directory and rustc reads a half-written tree.
 
-**Fix:** Each self-hosted Linux job writes `CARGO_HOME=$RUNNER_TEMP/cargo-home` into `GITHUB_ENV` before rust-toolchain/cache. Do not put `${{ runner.temp }}` in job-level `env` — GitHub fails the workflow with zero jobs.
+**Fix:** `scripts/ci_isolate_cargo_home.sh` pins `CARGO_HOME` and `CARGO_TARGET_DIR` under `RUNNER_TOOL_CACHE/<runner-name>/<job>` (not `~/.cargo`, not `RUNNER_TEMP`, not the git worktree). `actions/checkout` `git clean -ffdx` would wipe workspace `target/`; a temp home forced a cold crates.io unpack. rust-cache restores registry/git only when that disk is empty (`CARGO_CACHE_HIT_LOCAL!=1`) and never with `cache-targets`. Do not put `${{ runner.temp }}` in job-level `env` — GitHub fails the workflow with zero jobs.
 
-**Prevention:** Do not point extra runners at one OS home for Cargo. Separate `_work` is not enough.
+**Prevention:** Do not point extra runners at one OS home for Cargo. Separate `_work` is not enough. Do not restore GitHub cargo caches into a populated `CARGO_HOME`.
 
 ## TUI suggestion FailOpen test hits the LLM response cache
 

--- a/scripts/ci_isolate_cargo_home.sh
+++ b/scripts/ci_isolate_cargo_home.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+# Pin CARGO_HOME + CARGO_TARGET_DIR to directories that:
+#   - survive job teardown (not RUNNER_TEMP / not the git worktree)
+#   - are unique per Runner.Listener + GitHub job (not ~/.cargo)
+#
+# Three listeners share one OS user. A shared ~/.cargo/registry unpack
+# produced strum_macros E0583 / missing rustversion .d files. A temp
+# home avoided that but forced a cold crates.io fetch every job, and
+# `actions/checkout` `git clean -ffdx` wiped workspace `target/`.
+#
+# Usage (CI): sh scripts/ci_isolate_cargo_home.sh
+# Writes CARGO_HOME, CARGO_TARGET_DIR, CARGO_CACHE_HIT_LOCAL into
+# GITHUB_ENV when that file is set; always prints CARGO_HOME.
+
+set -eu
+
+sanitize() {
+    printf '%s' "$1" | tr -c 'A-Za-z0-9._-' '_'
+}
+
+job="$(sanitize "${GITHUB_JOB:-unknown}")"
+runner="$(sanitize "${RUNNER_NAME:-local}")"
+
+if [ -n "${RUNNER_TOOL_CACHE:-}" ]; then
+    cargo_base="${RUNNER_TOOL_CACHE}/whycodes-cargo"
+    target_base="${RUNNER_TOOL_CACHE}/whycodes-target"
+else
+    cargo_base="${HOME%/}/.cache/whycodes-ci-cargo"
+    target_base="${HOME%/}/.cache/whycodes-ci-target"
+fi
+
+home="${cargo_base}/${runner}/${job}"
+target="${target_base}/${runner}/${job}"
+
+case "$home" in
+    "${HOME%/}/.cargo"|"${HOME%/}/.cargo"/*)
+        printf 'error: refusing shared ~/.cargo as CARGO_HOME (%s)\n' "$home" >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p "$home" "$target"
+
+if [ -d "$home/registry/index" ] || [ -d "$home/registry/src" ]; then
+    hit=1
+else
+    hit=0
+fi
+
+printf 'CARGO_HOME=%s\n' "$home"
+printf 'CARGO_TARGET_DIR=%s\n' "$target"
+printf 'CARGO_CACHE_HIT_LOCAL=%s\n' "$hit"
+if [ -n "${GITHUB_ENV:-}" ]; then
+    {
+        printf 'CARGO_HOME=%s\n' "$home"
+        printf 'CARGO_TARGET_DIR=%s\n' "$target"
+        printf 'CARGO_CACHE_HIT_LOCAL=%s\n' "$hit"
+    } >>"$GITHUB_ENV"
+fi

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -98,12 +98,17 @@ if [ -z "${LLVM_PROFDATA:-}" ] && command -v llvm-profdata >/dev/null 2>&1; then
     export LLVM_PROFDATA
 fi
 
+# cargo-llvm-cov 0.9 rejects --target-dir. Default is workspace
+# `target/llvm-cov-target`, which `actions/checkout` wipes. Honor
+# CARGO_TARGET_DIR via CARGO_LLVM_COV_TARGET_DIR when CI pins it.
+if [ -n "${CARGO_TARGET_DIR:-}" ] && [ -z "${CARGO_LLVM_COV_TARGET_DIR:-}" ]; then
+    CARGO_LLVM_COV_TARGET_DIR="$CARGO_TARGET_DIR"
+    export CARGO_LLVM_COV_TARGET_DIR
+fi
+
 cov_cmd="cargo llvm-cov --workspace"
 if [ -n "$COVERAGE_FEATURES" ]; then
     cov_cmd="$cov_cmd --features $COVERAGE_FEATURES"
-fi
-if [ -n "${CARGO_TARGET_DIR:-}" ]; then
-    cov_cmd="$cov_cmd --target-dir $CARGO_TARGET_DIR"
 fi
 cov_cmd="$cov_cmd --ignore-filename-regex $IGNORE --fail-under-lines $FAIL_UNDER --summary-only -- --skip tests::watcher_picks_up_changes --skip picker_flow_over_real_index --skip launch_inherited_logins_retries_until_healthy --skip launch_isolated_home_and_tempdir_connect --skip launch_timeout_closes_stderr_then_hangs --skip launch_child_exit_is_startup_failed --skip launch_unsupported_version_does_not_retry --skip isolated_cwd_points_at_home_and_restores --skip git_log_status_diff_blame_and_commit_on_repo"
 
@@ -111,6 +116,9 @@ report_cmd="cargo llvm-cov report --json --ignore-filename-regex $CRATE_IGNORE -
 floors_cmd="python3 scripts/check_coverage_floors.py $REPORT_JSON"
 
 if [ "$dry_run" -eq 1 ]; then
+    if [ -n "${CARGO_LLVM_COV_TARGET_DIR:-}" ]; then
+        say "+ CARGO_LLVM_COV_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR"
+    fi
     say "+ $cov_cmd"
     say "+ $report_cmd > $REPORT_JSON"
     say "+ $floors_cmd"
@@ -137,11 +145,6 @@ fi
 set -- cargo llvm-cov --workspace
 if [ -n "$COVERAGE_FEATURES" ]; then
     set -- "$@" --features "$COVERAGE_FEATURES"
-fi
-# Default llvm-cov dir is workspace `target/llvm-cov-target`, which
-# `actions/checkout` wipes. Honor CARGO_TARGET_DIR when CI pins it.
-if [ -n "${CARGO_TARGET_DIR:-}" ]; then
-    set -- "$@" --target-dir "$CARGO_TARGET_DIR"
 fi
 set -- "$@" \
     --ignore-filename-regex "$IGNORE" \

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -102,6 +102,9 @@ cov_cmd="cargo llvm-cov --workspace"
 if [ -n "$COVERAGE_FEATURES" ]; then
     cov_cmd="$cov_cmd --features $COVERAGE_FEATURES"
 fi
+if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    cov_cmd="$cov_cmd --target-dir $CARGO_TARGET_DIR"
+fi
 cov_cmd="$cov_cmd --ignore-filename-regex $IGNORE --fail-under-lines $FAIL_UNDER --summary-only -- --skip tests::watcher_picks_up_changes --skip picker_flow_over_real_index --skip launch_inherited_logins_retries_until_healthy --skip launch_isolated_home_and_tempdir_connect --skip launch_timeout_closes_stderr_then_hangs --skip launch_child_exit_is_startup_failed --skip launch_unsupported_version_does_not_retry --skip isolated_cwd_points_at_home_and_restores --skip git_log_status_diff_blame_and_commit_on_repo"
 
 report_cmd="cargo llvm-cov report --json --ignore-filename-regex $CRATE_IGNORE --summary-only"
@@ -134,6 +137,11 @@ fi
 set -- cargo llvm-cov --workspace
 if [ -n "$COVERAGE_FEATURES" ]; then
     set -- "$@" --features "$COVERAGE_FEATURES"
+fi
+# Default llvm-cov dir is workspace `target/llvm-cov-target`, which
+# `actions/checkout` wipes. Honor CARGO_TARGET_DIR when CI pins it.
+if [ -n "${CARGO_TARGET_DIR:-}" ]; then
+    set -- "$@" --target-dir "$CARGO_TARGET_DIR"
 fi
 set -- "$@" \
     --ignore-filename-regex "$IGNORE" \

--- a/scripts/test_ci_isolate_cargo_home.sh
+++ b/scripts/test_ci_isolate_cargo_home.sh
@@ -101,8 +101,11 @@ home3="$(printf '%s\n' "$out3" | sed -n 's/^CARGO_HOME=//p')"
     exit 1
 }
 
+# Unset RUNNER_TOOL_CACHE: CI jobs inherit it, which would skip the
+# ~/.cache fallback this case is meant to cover.
 out4="$(
-    HOME="$tmp/home" \
+    env -u RUNNER_TOOL_CACHE \
+        HOME="$tmp/home" \
         RUNNER_NAME="local" \
         GITHUB_JOB="lint" \
         "$SCRIPT"

--- a/scripts/test_ci_isolate_cargo_home.sh
+++ b/scripts/test_ci_isolate_cargo_home.sh
@@ -122,6 +122,7 @@ need "shared-key: whycodes-ci-registry" "$wf"
 forbid 'RUNNER_TEMP/cargo-home' "$wf"
 
 dry="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$COV" --dry-run)"
-need "--target-dir /tmp/pinned-llvm-target" "$dry"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target" "$dry"
+forbid "--target-dir" "$dry"
 
 printf 'ok\n'

--- a/scripts/test_ci_isolate_cargo_home.sh
+++ b/scripts/test_ci_isolate_cargo_home.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env sh
+# Offline checks for scripts/ci_isolate_cargo_home.sh and ci.yml cache wiring.
+
+set -eu
+
+ROOT="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+SCRIPT="$ROOT/scripts/ci_isolate_cargo_home.sh"
+WF="$ROOT/.github/workflows/ci.yml"
+COV="$ROOT/scripts/coverage.sh"
+
+need() {
+    printf '%s\n' "$2" | grep -F -q -- "$1" || {
+        printf 'error: output missing %s\n' "$1" >&2
+        printf '%s\n' "$2" >&2
+        exit 1
+    }
+}
+
+forbid() {
+    if printf '%s\n' "$2" | grep -F -q -- "$1"; then
+        printf 'error: output should not contain %s\n' "$1" >&2
+        printf '%s\n' "$2" >&2
+        exit 1
+    fi
+}
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+envfile="$tmp/github.env"
+: >"$envfile"
+out1="$(
+    HOME="$tmp/home" \
+        RUNNER_TOOL_CACHE="$tmp/tools" \
+        RUNNER_NAME="1panel-ci-2" \
+        GITHUB_JOB="test" \
+        GITHUB_ENV="$envfile" \
+        "$SCRIPT"
+)"
+need "CARGO_HOME=" "$out1"
+need "CARGO_TARGET_DIR=" "$out1"
+need "CARGO_CACHE_HIT_LOCAL=0" "$out1"
+need "1panel-ci-2" "$out1"
+need "/test" "$out1"
+forbid "/.cargo" "$out1"
+grep -q '^CARGO_HOME=' "$envfile" || {
+    printf 'error: GITHUB_ENV missing CARGO_HOME\n' >&2
+    exit 1
+}
+grep -q '^CARGO_TARGET_DIR=' "$envfile" || {
+    printf 'error: GITHUB_ENV missing CARGO_TARGET_DIR\n' >&2
+    exit 1
+}
+
+home1="$(printf '%s\n' "$out1" | sed -n 's/^CARGO_HOME=//p')"
+target1="$(printf '%s\n' "$out1" | sed -n 's/^CARGO_TARGET_DIR=//p')"
+[ -d "$home1" ] && [ -d "$target1" ] || {
+    printf 'error: homes were not created\n' >&2
+    exit 1
+}
+[ "$home1" != "$target1" ] || {
+    printf 'error: CARGO_HOME must not equal CARGO_TARGET_DIR\n' >&2
+    exit 1
+}
+
+mkdir -p "$home1/registry/index"
+out_hit="$(
+    HOME="$tmp/home" \
+        RUNNER_TOOL_CACHE="$tmp/tools" \
+        RUNNER_NAME="1panel-ci-2" \
+        GITHUB_JOB="test" \
+        "$SCRIPT"
+)"
+need "CARGO_CACHE_HIT_LOCAL=1" "$out_hit"
+
+out2="$(
+    HOME="$tmp/home" \
+        RUNNER_TOOL_CACHE="$tmp/tools" \
+        RUNNER_NAME="1panel-ci-2" \
+        GITHUB_JOB="coverage" \
+        "$SCRIPT"
+)"
+need "/coverage" "$out2"
+if [ "$out1" = "$out2" ]; then
+    printf 'error: test vs coverage must not share CARGO_HOME\n' >&2
+    printf '%s\n' "$out1" "$out2" >&2
+    exit 1
+fi
+
+out3="$(
+    HOME="$tmp/home" \
+        RUNNER_TOOL_CACHE="$tmp/tools" \
+        RUNNER_NAME="1panel-ci-3" \
+        GITHUB_JOB="test" \
+        "$SCRIPT"
+)"
+need "1panel-ci-3" "$out3"
+home3="$(printf '%s\n' "$out3" | sed -n 's/^CARGO_HOME=//p')"
+[ "$home1" != "$home3" ] || {
+    printf 'error: two listeners must not share CARGO_HOME\n' >&2
+    exit 1
+}
+
+out4="$(
+    HOME="$tmp/home" \
+        RUNNER_NAME="local" \
+        GITHUB_JOB="lint" \
+        "$SCRIPT"
+)"
+need ".cache/whycodes-ci-cargo" "$out4"
+need ".cache/whycodes-ci-target" "$out4"
+forbid "${tmp}/home/.cargo" "$out4"
+
+wf="$(cat "$WF")"
+need "scripts/ci_isolate_cargo_home.sh" "$wf"
+need "cache-targets: false" "$wf"
+need "CARGO_CACHE_HIT_LOCAL" "$wf"
+need "shared-key: whycodes-ci-registry" "$wf"
+forbid 'RUNNER_TEMP/cargo-home' "$wf"
+
+dry="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$COV" --dry-run)"
+need "--target-dir /tmp/pinned-llvm-target" "$dry"
+
+printf 'ok\n'

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -53,6 +53,9 @@ need "--fail-under-lines 100" "$dry100"
 dryjson="$(REPORT_JSON=/tmp/custom-cov.json "$SCRIPT" --dry-run)"
 need "/tmp/custom-cov.json" "$dryjson"
 
+drytgt="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$SCRIPT" --dry-run)"
+need "--target-dir /tmp/pinned-llvm-target" "$drytgt"
+
 # rustup llvm-cov is under rustlib/bin, not PATH. The wrapper must prepend
 # that dir so CI (and rustup clones) do not fail with `llvm-cov not found`.
 src="$(cat "$SCRIPT")"

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -54,7 +54,8 @@ dryjson="$(REPORT_JSON=/tmp/custom-cov.json "$SCRIPT" --dry-run)"
 need "/tmp/custom-cov.json" "$dryjson"
 
 drytgt="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$SCRIPT" --dry-run)"
-need "--target-dir /tmp/pinned-llvm-target" "$drytgt"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target" "$drytgt"
+forbid "--target-dir" "$drytgt"
 
 # rustup llvm-cov is under rustlib/bin, not PATH. The wrapper must prepend
 # that dir so CI (and rustup clones) do not fail with `llvm-cov not found`.


### PR DESCRIPTION
## Why

Linux CI was cold every job:

- `CARGO_HOME=$RUNNER_TEMP/cargo-home` died with the job, so crates.io unpacked again.
- `actions/checkout` `git clean -ffdx` wiped workspace `target/`.
- `rust-cache` `save-if: main` plus a shared key never refilled that empty temp home on PRs.

Three listeners still must not share `~/.cargo` (`strum_macros` E0583).

## Change

- `scripts/ci_isolate_cargo_home.sh` pins `CARGO_HOME` and `CARGO_TARGET_DIR` to `RUNNER_TOOL_CACHE/<runner>/<job>` (disk, isolated).
- `rust-cache` restores registry/git **only** when that disk is empty (`CARGO_CACHE_HIT_LOCAL!=1`) and never restores `target/` (`cache-targets: false`).
- `coverage.sh` honors `CARGO_TARGET_DIR` so llvm-cov does not write into the wiped worktree.
- Offline gate: `scripts/test_ci_isolate_cargo_home.sh` (wired into Lint).

Gates unchanged: fmt, clippy, budgets, workspace tests, coverage floors, release CLI build.
