### PR TITLE
chore(release): bump version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4748,7 +4748,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-agent"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-auth"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64 0.23.1",
  "chrono",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-cli"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -4843,14 +4843,14 @@ dependencies = [
 
 [[package]]
 name = "whycodes-command-risk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
 ]
 
 [[package]]
 name = "whycodes-config"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4862,7 +4862,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-core"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "directories",
@@ -4879,7 +4879,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-format"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "mermaid-text",
@@ -4893,7 +4893,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-function"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde_json",
  "whycodes-core",
@@ -4901,7 +4901,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-import"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4914,7 +4914,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-index"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "criterion",
  "ignore",
@@ -4927,7 +4927,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-llm"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4950,7 +4950,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-lsp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -4963,7 +4963,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-mcp"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-stream",
  "axum",
@@ -4982,7 +4982,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-memory"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "serde",
@@ -5001,7 +5001,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-plugin"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "reqwest",
  "serde",
@@ -5015,7 +5015,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-protocol"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-sandbox"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "libc",
  "tempfile",
@@ -5035,7 +5035,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-schema"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-sdk"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "axum",
  "futures",
@@ -5059,7 +5059,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5087,7 +5087,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-session"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "futures",
@@ -5104,7 +5104,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-skill"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -5118,7 +5118,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-storage"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "rusqlite",
@@ -5132,7 +5132,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-tools"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "whycodes-tui"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "base64 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,7 +10,7 @@ use whycodes_protocol::OutputFormat;
 /// Crate version only (semver from Cargo.toml).
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
 
-/// Full version string: `0.4.0 (abc1234 2026-09-02)`.
+/// Full version string: `0.5.0 (abc1234 2026-09-12)`.
 ///
 /// Git hash and build date come from `build.rs` so release binaries and
 /// `whycodes --version` / install smoke checks identify an exact build.

--- a/crates/cli/tests/cli_args.rs
+++ b/crates/cli/tests/cli_args.rs
@@ -48,7 +48,7 @@ fn test_version_includes_semver_and_build_meta() {
     let o = run(&["--version"]);
     assert_ok(&["--version"], &o);
     let s = String::from_utf8_lossy(&o.stdout);
-    // clap prints: "whycodes 0.4.0 (abc1234 2026-09-02)"
+    // clap prints: "whycodes 0.5.0 (abc1234 2026-09-12)"
     assert!(
         s.contains(env!("CARGO_PKG_VERSION")),
         "version should include crate semver: {s}"

--- a/crates/llm/src/client_identity.rs
+++ b/crates/llm/src/client_identity.rs
@@ -8,7 +8,7 @@ use std::sync::OnceLock;
 
 use reqwest::RequestBuilder;
 
-/// `User-Agent` value, e.g. `whycodes/0.4.0`.
+/// `User-Agent` value, e.g. `whycodes/0.5.0`.
 pub const USER_AGENT: &str = concat!("whycodes/", env!("CARGO_PKG_VERSION"));
 
 /// OpenRouter-style app title (`X-Title`).

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@whycorporation/whycodes-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@whycorporation/whycodes-sdk",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^26.4.1",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@whycorporation/whycodes-sdk",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Thin TypeScript client for whycodes serve (protocol v1)",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Why

Cut the next minor release after v0.4.0 (2026-09-02). Workspace crates and the TypeScript SDK must report 0.5.0 so tagged binaries and `whycodes --version` match.

Homebrew `Formula/whycodes.rb` is left on 0.4.0; `release.yml` rewrites it from SHA256SUMS after the `v0.5.0` tag.

## After merge

Tag `v0.5.0` on the bump commit. That starts `.github/workflows/release.yml` (Linux/macOS/Windows artifacts, GitHub Release, formula bump, landing refresh).

Highlights since v0.4.0 (for the annotated tag):

- Import MCP, permissions, and hooks from other agents; home-screen confirm
- Provider/model system-prompt overlays from markdown
- Configurable LSP servers
- Edit can name a span from tagged read/grep lines
- Grep prune with in-memory content trigrams
- First-frame TUI paint before Agent/SQLite/git; Windows `--version` via GetCommandLineW
- Question prompts in auto; GitHub token from gh/git login
- Isolated persistent Cargo cache on self-hosted CI (~24m → ~5m after lint)
