### PR TITLE
ci: keep llvm-cov traces out of the compile cache

### DIFF
--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2390,9 +2390,9 @@ Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs al
 
 **Root cause:** `CARGO_LLVM_COV_TARGET_DIR` points at a persistent per-job cache. Previous llvm-cov `.profraw` files mixed into the next merge.
 
-**Fix:** Write Cargo's `CACHEDIR.TAG` into the persistent target dir, delete leftover `*.profraw`/`*.profdata`, then `cargo llvm-cov clean --workspace`. Without the tag, `clean` errors and the traces stay.
+**Fix:** Keep compile artifacts in `CARGO_TARGET_DIR`. Put llvm-cov traces in `$CARGO_TARGET_DIR/llvm-cov-target` and `rm -rf` that dir every Coverage run. Stamp `CACHEDIR.TAG` with `printf` (exact LF signature). Do not call `cargo llvm-cov clean` on the persistent compile cache.
 
-**Prevention:** Persistent coverage `target/` must be a Cargo cache dir (CACHEDIR.TAG) and must drop profraw each run.
+**Prevention:** Never mix llvm-cov traces into a long-lived compile `target/`. Never write `CACHEDIR.TAG` via a heredoc from a CRLF-checked-out script.
 
 ## SDK launch: ephemeral port stolen before spawn
 

--- a/scripts/ci_isolate_cargo_home.sh
+++ b/scripts/ci_isolate_cargo_home.sh
@@ -40,15 +40,9 @@ case "$home" in
 esac
 
 mkdir -p "$home" "$target"
-# cargo llvm-cov clean refuses a target dir without this signature
-# (Coverage then mixed stale .profraw and tanked crate floors).
-if [ ! -f "$target/CACHEDIR.TAG" ]; then
-    cat >"$target/CACHEDIR.TAG" <<'EOF'
-Signature: 8a477f597d28d172789c096e48218643
-# This file is a cache directory tag created by cargo.
-# For information about cache directory tags see https://bford.info/cachedir/
-EOF
-fi
+# Cargo (and llvm-cov clean) require this exact first line. A heredoc from a
+# CRLF-checked-out script produced "invalid signature"; printf is one LF.
+printf 'Signature: 8a477f597d28d172789c096e48218643\n' >"$target/CACHEDIR.TAG"
 
 if [ -d "$home/registry/index" ] || [ -d "$home/registry/src" ]; then
     hit=1

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -99,10 +99,11 @@ if [ -z "${LLVM_PROFDATA:-}" ] && command -v llvm-profdata >/dev/null 2>&1; then
 fi
 
 # cargo-llvm-cov 0.9 rejects --target-dir. Default is workspace
-# `target/llvm-cov-target`, which `actions/checkout` wipes. Honor
-# CARGO_TARGET_DIR via CARGO_LLVM_COV_TARGET_DIR when CI pins it.
+# `target/llvm-cov-target`, which `actions/checkout` wipes. Keep compiled
+# artifacts in CARGO_TARGET_DIR; put traces in a sibling llvm-cov-target
+# that this script deletes every run (stale .profraw mixed floors to 54%).
 if [ -n "${CARGO_TARGET_DIR:-}" ] && [ -z "${CARGO_LLVM_COV_TARGET_DIR:-}" ]; then
-    CARGO_LLVM_COV_TARGET_DIR="$CARGO_TARGET_DIR"
+    CARGO_LLVM_COV_TARGET_DIR="$CARGO_TARGET_DIR/llvm-cov-target"
     export CARGO_LLVM_COV_TARGET_DIR
 fi
 
@@ -119,8 +120,7 @@ if [ "$dry_run" -eq 1 ]; then
     if [ -n "${CARGO_LLVM_COV_TARGET_DIR:-}" ]; then
         say "+ CARGO_LLVM_COV_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR"
     fi
-    say "+ write CACHEDIR.TAG; delete *.profraw *.profdata"
-    say "+ cargo llvm-cov clean --workspace"
+    say "+ rm -rf llvm-cov-target (CACHEDIR.TAG + traces)"
     say "+ $cov_cmd"
     say "+ $report_cmd > $REPORT_JSON"
     say "+ $floors_cmd"
@@ -144,21 +144,12 @@ if [ -z "${LLVM_COV:-}" ] || ! command -v "$LLVM_COV" >/dev/null 2>&1; then
 fi
 
 # Rebuild argv without going through the shell so regex metacharacters stay literal.
-# Persistent CARGO_TARGET_DIR keeps stale .profraw from the previous job.
-# Mixing those files tanks crate floors (index 74.7%, sdk 54% on PR 93).
-# cargo llvm-cov clean also refuses a dir without CACHEDIR.TAG — write one,
-# delete leftover traces, then clean.
-cov_root="${CARGO_LLVM_COV_TARGET_DIR:-${CARGO_TARGET_DIR:-target}}"
+# Drop coverage traces only. Do not `llvm-cov clean` the compile cache — it
+# refuses a persistent dir whose CACHEDIR.TAG is not Cargo's exact bytes.
+cov_root="${CARGO_LLVM_COV_TARGET_DIR:-target/llvm-cov-target}"
+rm -rf "$cov_root"
 mkdir -p "$cov_root"
-if [ ! -f "$cov_root/CACHEDIR.TAG" ]; then
-    cat >"$cov_root/CACHEDIR.TAG" <<'EOF'
-Signature: 8a477f597d28d172789c096e48218643
-# This file is a cache directory tag created by cargo.
-# For information about cache directory tags see https://bford.info/cachedir/
-EOF
-fi
-find "$cov_root" \( -name '*.profraw' -o -name '*.profdata' \) -delete
-run cargo llvm-cov clean --workspace
+printf 'Signature: 8a477f597d28d172789c096e48218643\n' >"$cov_root/CACHEDIR.TAG"
 
 set -- cargo llvm-cov --workspace
 if [ -n "$COVERAGE_FEATURES" ]; then

--- a/scripts/test_ci_isolate_cargo_home.sh
+++ b/scripts/test_ci_isolate_cargo_home.sh
@@ -130,7 +130,7 @@ need "shared-key: whycodes-ci-registry" "$wf"
 forbid 'RUNNER_TEMP/cargo-home' "$wf"
 
 dry="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$COV" --dry-run)"
-need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target" "$dry"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target/llvm-cov-target" "$dry"
 forbid "--target-dir" "$dry"
 
 printf 'ok\n'

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -33,8 +33,8 @@ printf '%s\n' "$help" | grep -q '^set ' && {
 
 dry="$("$SCRIPT" --dry-run)"
 need "cargo llvm-cov --workspace" "$dry"
-need "cargo llvm-cov clean --workspace" "$dry"
-need "CACHEDIR.TAG" "$dry"
+need "rm -rf llvm-cov-target" "$dry"
+forbid "cargo llvm-cov clean --workspace" "$dry"
 need "--fail-under-lines 82" "$dry"
 need "--skip tests::watcher_picks_up_changes" "$dry"
 need "--skip picker_flow_over_real_index" "$dry"
@@ -58,7 +58,7 @@ dryjson="$(REPORT_JSON=/tmp/custom-cov.json "$SCRIPT" --dry-run)"
 need "/tmp/custom-cov.json" "$dryjson"
 
 drytgt="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$SCRIPT" --dry-run)"
-need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target" "$drytgt"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target/llvm-cov-target" "$drytgt"
 forbid "--target-dir" "$drytgt"
 
 # rustup llvm-cov is under rustlib/bin, not PATH. The wrapper must prepend


### PR DESCRIPTION
## Why

`main` Coverage after #93 still failed with the same fake floors (`whycodes-index` 74.7%, `whycodes-sdk` 54%). Tests passed.

`cargo llvm-cov clean` printed `invalid signature in CACHEDIR.TAG` (heredoc from a Windows-checked-out script) and left stale `.profraw` in the persistent compile cache.

## Change

- Stamp `CACHEDIR.TAG` with `printf` (exact LF signature).
- Put llvm-cov traces in `$CARGO_TARGET_DIR/llvm-cov-target` and `rm -rf` that dir every Coverage run.
- Do not call `cargo llvm-cov clean` on the compile cache.

Do not tag v0.5.0 until this is green on `main`.
