### PR TITLE
ci: put llvm-cov traces in RUNNER_TEMP, not the compile cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,13 @@ jobs:
       # checked by Python instead of 12 separate `cargo llvm-cov -p` re-runs.
       # Wrapper flags live in scripts/coverage.sh (same as local `scripts/coverage.sh`).
       - name: Measure coverage
-        # Unique path so two coverage jobs on one host cannot clobber /tmp/cov.json.
-        run: COVERAGE_FEATURES=whycodes-storage/bundled REPORT_JSON="$RUNNER_TEMP/cov.json" scripts/coverage.sh
+        env:
+          # Job-scoped; do not put ${{ runner.temp }} in job-level env (0-job
+          # workflow failure). Traces must not share CARGO_TARGET_DIR.
+          CARGO_LLVM_COV_TARGET_DIR: ${{ runner.temp }}/llvm-cov-target
+          COVERAGE_FEATURES: whycodes-storage/bundled
+          REPORT_JSON: ${{ runner.temp }}/cov.json
+        run: scripts/coverage.sh
 
   build:
     name: Build (linux)

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -9,10 +9,11 @@ breakdown.
 scripts/coverage.sh
 ```
 
-Same flags as the CI `Coverage (line floor)` job: `cargo llvm-cov clean
---workspace` (stale `.profraw` in a persistent `CARGO_TARGET_DIR` tanks
-crate floors), one `cargo llvm-cov --workspace` instrumentation, then a
-JSON report and `python3 scripts/check_coverage_floors.py`.
+Same flags as the CI `Coverage (line floor)` job: traces go to
+`$RUNNER_TEMP/llvm-cov-target` (or `${CARGO_TARGET_DIR}-llvm-cov` locally),
+leftover `*.profraw` under the compile cache are deleted, then one
+`cargo llvm-cov --workspace` instrumentation, a JSON report, and
+`python3 scripts/check_coverage_floors.py`.
 
 ```bash
 scripts/coverage.sh --dry-run          # print the cargo/python argv

--- a/docs/knowhow.md
+++ b/docs/knowhow.md
@@ -2390,9 +2390,9 @@ Linux CI wall-clock is lint then max(test, coverage, build). Those three jobs al
 
 **Root cause:** `CARGO_LLVM_COV_TARGET_DIR` points at a persistent per-job cache. Previous llvm-cov `.profraw` files mixed into the next merge.
 
-**Fix:** Keep compile artifacts in `CARGO_TARGET_DIR`. Put llvm-cov traces in `$CARGO_TARGET_DIR/llvm-cov-target` and `rm -rf` that dir every Coverage run. Stamp `CACHEDIR.TAG` with `printf` (exact LF signature). Do not call `cargo llvm-cov clean` on the persistent compile cache.
+**Fix:** On CI, put traces in `$RUNNER_TEMP/llvm-cov-target` (job-scoped). Locally, `${CARGO_TARGET_DIR}-llvm-cov`. `rm -rf` that dir, `find`-delete leftover `*.profraw` under `CARGO_TARGET_DIR`, set `LLVM_PROFILE_FILE`. Stamp `CACHEDIR.TAG` with `printf`. Do not `cargo llvm-cov clean` the compile cache.
 
-**Prevention:** Never mix llvm-cov traces into a long-lived compile `target/`. Never write `CACHEDIR.TAG` via a heredoc from a CRLF-checked-out script.
+**Prevention:** Coverage traces must not share a directory with a long-lived compile cache. Never write `CACHEDIR.TAG` via a heredoc from a CRLF-checked-out script.
 
 ## SDK launch: ephemeral port stolen before spawn
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -99,11 +99,18 @@ if [ -z "${LLVM_PROFDATA:-}" ] && command -v llvm-profdata >/dev/null 2>&1; then
 fi
 
 # cargo-llvm-cov 0.9 rejects --target-dir. Default is workspace
-# `target/llvm-cov-target`, which `actions/checkout` wipes. Keep compiled
-# artifacts in CARGO_TARGET_DIR; put traces in a sibling llvm-cov-target
-# that this script deletes every run (stale .profraw mixed floors to 54%).
-if [ -n "${CARGO_TARGET_DIR:-}" ] && [ -z "${CARGO_LLVM_COV_TARGET_DIR:-}" ]; then
-    CARGO_LLVM_COV_TARGET_DIR="$CARGO_TARGET_DIR/llvm-cov-target"
+# `target/llvm-cov-target`, which `actions/checkout` wipes.
+# Traces MUST NOT live under persistent CARGO_TARGET_DIR: leftover .profraw
+# mixed floors to 54% (index 74.7%). Prefer RUNNER_TEMP (job-scoped, gone
+# after the job). Locally, use a sibling of CARGO_TARGET_DIR that we rm -rf.
+if [ -z "${CARGO_LLVM_COV_TARGET_DIR:-}" ]; then
+    if [ -n "${RUNNER_TEMP:-}" ]; then
+        CARGO_LLVM_COV_TARGET_DIR="$RUNNER_TEMP/llvm-cov-target"
+    elif [ -n "${CARGO_TARGET_DIR:-}" ]; then
+        CARGO_LLVM_COV_TARGET_DIR="${CARGO_TARGET_DIR%/}-llvm-cov"
+    else
+        CARGO_LLVM_COV_TARGET_DIR="$ROOT/target/llvm-cov-target"
+    fi
     export CARGO_LLVM_COV_TARGET_DIR
 fi
 
@@ -119,8 +126,9 @@ floors_cmd="python3 scripts/check_coverage_floors.py $REPORT_JSON"
 if [ "$dry_run" -eq 1 ]; then
     if [ -n "${CARGO_LLVM_COV_TARGET_DIR:-}" ]; then
         say "+ CARGO_LLVM_COV_TARGET_DIR=$CARGO_LLVM_COV_TARGET_DIR"
+        say "+ LLVM_PROFILE_FILE=$CARGO_LLVM_COV_TARGET_DIR/whycodes-%p-%m.profraw"
     fi
-    say "+ rm -rf llvm-cov-target (CACHEDIR.TAG + traces)"
+    say "+ rm -rf \$CARGO_LLVM_COV_TARGET_DIR; purge *.profraw from CARGO_TARGET_DIR"
     say "+ $cov_cmd"
     say "+ $report_cmd > $REPORT_JSON"
     say "+ $floors_cmd"
@@ -144,12 +152,17 @@ if [ -z "${LLVM_COV:-}" ] || ! command -v "$LLVM_COV" >/dev/null 2>&1; then
 fi
 
 # Rebuild argv without going through the shell so regex metacharacters stay literal.
-# Drop coverage traces only. Do not `llvm-cov clean` the compile cache — it
-# refuses a persistent dir whose CACHEDIR.TAG is not Cargo's exact bytes.
-cov_root="${CARGO_LLVM_COV_TARGET_DIR:-target/llvm-cov-target}"
+# Drop coverage traces only. Never `llvm-cov clean` the compile cache.
+cov_root="$CARGO_LLVM_COV_TARGET_DIR"
 rm -rf "$cov_root"
 mkdir -p "$cov_root"
 printf 'Signature: 8a477f597d28d172789c096e48218643\n' >"$cov_root/CACHEDIR.TAG"
+# Previous jobs wrote traces into CARGO_TARGET_DIR itself. Purge them or
+# llvm-cov merges garbage even when CARGO_LLVM_COV_TARGET_DIR is elsewhere.
+if [ -n "${CARGO_TARGET_DIR:-}" ] && [ -d "$CARGO_TARGET_DIR" ]; then
+    find "$CARGO_TARGET_DIR" \( -name '*.profraw' -o -name '*.profdata' \) -delete
+fi
+export LLVM_PROFILE_FILE="$cov_root/whycodes-%p-%m.profraw"
 
 set -- cargo llvm-cov --workspace
 if [ -n "$COVERAGE_FEATURES" ]; then

--- a/scripts/test_ci_isolate_cargo_home.sh
+++ b/scripts/test_ci_isolate_cargo_home.sh
@@ -127,10 +127,18 @@ need "scripts/ci_isolate_cargo_home.sh" "$wf"
 need "cache-targets: false" "$wf"
 need "CARGO_CACHE_HIT_LOCAL" "$wf"
 need "shared-key: whycodes-ci-registry" "$wf"
+need "CARGO_LLVM_COV_TARGET_DIR: \${{ runner.temp }}/llvm-cov-target" "$wf"
 forbid 'RUNNER_TEMP/cargo-home' "$wf"
 
 dry="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$COV" --dry-run)"
-need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target/llvm-cov-target" "$dry"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target-llvm-cov" "$dry"
 forbid "--target-dir" "$dry"
+
+dryci="$(
+    RUNNER_TEMP=/tmp/gha-runner-temp \
+        CARGO_TARGET_DIR=/tmp/pinned-llvm-target \
+        "$COV" --dry-run
+)"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/gha-runner-temp/llvm-cov-target" "$dryci"
 
 printf 'ok\n'

--- a/scripts/test_ci_isolate_cargo_home.sh
+++ b/scripts/test_ci_isolate_cargo_home.sh
@@ -130,12 +130,17 @@ need "shared-key: whycodes-ci-registry" "$wf"
 need "CARGO_LLVM_COV_TARGET_DIR: \${{ runner.temp }}/llvm-cov-target" "$wf"
 forbid 'RUNNER_TEMP/cargo-home' "$wf"
 
-dry="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$COV" --dry-run)"
+dry="$(
+    env -u RUNNER_TEMP -u CARGO_LLVM_COV_TARGET_DIR \
+        CARGO_TARGET_DIR=/tmp/pinned-llvm-target \
+        "$COV" --dry-run
+)"
 need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target-llvm-cov" "$dry"
 forbid "--target-dir" "$dry"
 
 dryci="$(
-    RUNNER_TEMP=/tmp/gha-runner-temp \
+    env -u CARGO_LLVM_COV_TARGET_DIR \
+        RUNNER_TEMP=/tmp/gha-runner-temp \
         CARGO_TARGET_DIR=/tmp/pinned-llvm-target \
         "$COV" --dry-run
 )"

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -57,12 +57,19 @@ need "--fail-under-lines 100" "$dry100"
 dryjson="$(REPORT_JSON=/tmp/custom-cov.json "$SCRIPT" --dry-run)"
 need "/tmp/custom-cov.json" "$dryjson"
 
-drytgt="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$SCRIPT" --dry-run)"
+# Unset RUNNER_TEMP: CI jobs inherit it, which would skip the local
+# ${CARGO_TARGET_DIR}-llvm-cov fallback this case is meant to cover.
+drytgt="$(
+    env -u RUNNER_TEMP -u CARGO_LLVM_COV_TARGET_DIR \
+        CARGO_TARGET_DIR=/tmp/pinned-llvm-target \
+        "$SCRIPT" --dry-run
+)"
 need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target-llvm-cov" "$drytgt"
 forbid "--target-dir" "$drytgt"
 
 dryci="$(
-    RUNNER_TEMP=/tmp/gha-runner-temp \
+    env -u CARGO_LLVM_COV_TARGET_DIR \
+        RUNNER_TEMP=/tmp/gha-runner-temp \
         CARGO_TARGET_DIR=/tmp/pinned-llvm-target \
         "$SCRIPT" --dry-run
 )"

--- a/scripts/test_coverage.sh
+++ b/scripts/test_coverage.sh
@@ -33,7 +33,7 @@ printf '%s\n' "$help" | grep -q '^set ' && {
 
 dry="$("$SCRIPT" --dry-run)"
 need "cargo llvm-cov --workspace" "$dry"
-need "rm -rf llvm-cov-target" "$dry"
+need "purge *.profraw from CARGO_TARGET_DIR" "$dry"
 forbid "cargo llvm-cov clean --workspace" "$dry"
 need "--fail-under-lines 82" "$dry"
 need "--skip tests::watcher_picks_up_changes" "$dry"
@@ -58,8 +58,16 @@ dryjson="$(REPORT_JSON=/tmp/custom-cov.json "$SCRIPT" --dry-run)"
 need "/tmp/custom-cov.json" "$dryjson"
 
 drytgt="$(CARGO_TARGET_DIR=/tmp/pinned-llvm-target "$SCRIPT" --dry-run)"
-need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target/llvm-cov-target" "$drytgt"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/pinned-llvm-target-llvm-cov" "$drytgt"
 forbid "--target-dir" "$drytgt"
+
+dryci="$(
+    RUNNER_TEMP=/tmp/gha-runner-temp \
+        CARGO_TARGET_DIR=/tmp/pinned-llvm-target \
+        "$SCRIPT" --dry-run
+)"
+need "CARGO_LLVM_COV_TARGET_DIR=/tmp/gha-runner-temp/llvm-cov-target" "$dryci"
+need "LLVM_PROFILE_FILE=/tmp/gha-runner-temp/llvm-cov-target/whycodes-%p-%m.profraw" "$dryci"
 
 # rustup llvm-cov is under rustlib/bin, not PATH. The wrapper must prepend
 # that dir so CI (and rustup clones) do not fail with `llvm-cov not found`.


### PR DESCRIPTION
## Why

Coverage on `main` keeps failing with fake floors (`whycodes-index` 74.7%, `whycodes-sdk` 54%) while tests pass. Stale `.profraw` in the persistent compile cache (`CARGO_TARGET_DIR`) is merged into the next run. `cargo llvm-cov clean` refuses that dir (`invalid signature in CACHEDIR.TAG`).

## Change

- CI: `CARGO_LLVM_COV_TARGET_DIR=$RUNNER_TEMP/llvm-cov-target` (job-scoped, gone after the job). Set in the step `env`, not job-level (that 0-job-fails the workflow).
- Local: `${CARGO_TARGET_DIR}-llvm-cov` (sibling, not nested).
- `rm -rf` the traces dir; `find`-delete leftover `*.profraw` under the compile cache; set `LLVM_PROFILE_FILE`.
- Offline tests in `scripts/test_coverage.sh` and `scripts/test_ci_isolate_cargo_home.sh`.

Do not tag v0.5.0 until `main` Coverage is green.
